### PR TITLE
feat: 카테고리 조회 API 구현 (부모/자식)

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/category/api/CategoryController.java
+++ b/src/main/java/com/promesa/promesa/domain/category/api/CategoryController.java
@@ -1,0 +1,30 @@
+package com.promesa.promesa.domain.category.api;
+
+import com.promesa.promesa.domain.category.application.CategoryService;
+import com.promesa.promesa.domain.category.domain.Category;
+import com.promesa.promesa.domain.category.dto.CategoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @GetMapping("/parent")
+    public ResponseEntity<List<CategoryResponse>> getParentCategories() {
+        return ResponseEntity.ok(categoryService.getParentCategories());
+    }
+
+    @GetMapping("/child")
+    public ResponseEntity<List<CategoryResponse>> getChildCategories(@RequestParam Long parentId) {
+        return ResponseEntity.ok(categoryService.getChildCategories(parentId));
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/category/application/CategoryService.java
+++ b/src/main/java/com/promesa/promesa/domain/category/application/CategoryService.java
@@ -1,0 +1,28 @@
+package com.promesa.promesa.domain.category.application;
+
+import com.promesa.promesa.domain.category.dao.CategoryRepository;
+import com.promesa.promesa.domain.category.domain.Category;
+import com.promesa.promesa.domain.category.dto.CategoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryResponse> getParentCategories() {
+        return categoryRepository.findByParentIsNull().stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
+
+    public List<CategoryResponse> getChildCategories(Long parentId){
+        return categoryRepository.findByParentId(parentId).stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/category/dao/CategoryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/category/dao/CategoryRepository.java
@@ -3,5 +3,10 @@ package com.promesa.promesa.domain.category.dao;
 import com.promesa.promesa.domain.category.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByParentIsNull();
+
+    List<Category> findByParentId(Long parentId);
 }

--- a/src/main/java/com/promesa/promesa/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/category/dto/CategoryResponse.java
@@ -1,0 +1,9 @@
+package com.promesa.promesa.domain.category.dto;
+
+import com.promesa.promesa.domain.category.domain.Category;
+
+public record CategoryResponse(Long id, String name) {
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(category.getId(), category.getName());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   config:
     import: optional:file:.env[.properties]
+  profiles:
+    active: local
 
   security:
     oauth2:
@@ -9,7 +11,7 @@ spring:
           kakao:
             client-id: 7643970cb5bdb570ac7c688d2c6ea85e
             client-secret: ""
-            redirect-uri: http://localhost:8085/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8081/login/oauth2/code/kakao
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope: profile_nickname, profile_image


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #15

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- **부모 카테고리**(부모가 없는 카테고리) 목록 반환
      `GET /categories/parent`
<img src="https://github.com/user-attachments/assets/714de0df-20d1-4401-b30a-b94f067588ec" width="400"/>

- 특정 부모 ID를 가지는 **자식 카테고리** 목록 반환
      `GET /categories/child?parentId=`
<img src="https://github.com/user-attachments/assets/4c3348bc-cb1f-4d31-ae76-56c0c5526d13" width="400"/>

- CategoryResponse DTO로 **응답 구조 통일**

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
