### PR TITLE
feat: 이미지 주소를 presignedURL로 반환

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -41,7 +41,7 @@ if sudo nginx -t; then
 else
   echo "ERROR: nginx 설정 문법 오류. reload 취소합니다."
   exit 1
-fi
+fi  
 
 # 이전 포트 컨테이너 정리
 if [ "$CURRENT" == "8081" ]; then

--- a/src/main/java/com/promesa/promesa/common/application/S3Service.java
+++ b/src/main/java/com/promesa/promesa/common/application/S3Service.java
@@ -1,0 +1,57 @@
+package com.promesa.promesa.common.application;
+
+import com.promesa.promesa.common.exception.InternalServerError;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${aws.s3.presigned.expire-minutes}")
+    private long expireMinutes;
+
+    /**
+     * PresignedUrl 생성
+     * @param bucketName    S3 버킷 이름
+     * @param keyName   객체 키
+     * @return  유효한 presigned URL
+     */
+    public String createPresignedGetUrl(String bucketName, String keyName) {
+        try {
+
+            GetObjectRequest objectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(keyName)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(expireMinutes))  // 만료 시간 설정
+                    .getObjectRequest(objectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+
+            log.info("Presigned URL: [{}]", presignedRequest.url().toString());
+            log.info("HTTP method: [{}]", presignedRequest.httpRequest().method());
+
+            return presignedRequest.url().toExternalForm();
+
+        }catch (Exception e){
+            log.error("Presigned URL 생성 실패: {}/{}", bucketName, keyName, e);
+            throw InternalServerError.EXCEPTION;
+        }
+    }
+
+}

--- a/src/main/java/com/promesa/promesa/common/config/S3/S3Config.java
+++ b/src/main/java/com/promesa/promesa/common/config/S3/S3Config.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile("prod")
 @Slf4j
 public class S3Config {
 

--- a/src/main/java/com/promesa/promesa/common/config/S3/S3Config.java
+++ b/src/main/java/com/promesa/promesa/common/config/S3/S3Config.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,8 +24,15 @@ public class S3Config {
 
     @Bean
     public S3Client amazoneS3(){
-
         return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner amazonS3Presigner(){
+        return S3Presigner.builder()
                 .region(Region.AP_NORTHEAST_2)
                 .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();

--- a/src/main/java/com/promesa/promesa/common/exception/InternalServerError.java
+++ b/src/main/java/com/promesa/promesa/common/exception/InternalServerError.java
@@ -1,0 +1,10 @@
+package com.promesa.promesa.common.exception;
+
+import com.promesa.promesa.domain.example.exception.ExampleErrorCode;
+
+public class InternalServerError extends PromesaCodeException {
+    public static final PromesaCodeException EXCEPTION = new InternalServerError();
+    private InternalServerError() {
+        super(ExampleErrorCode.EXAMPLE_ERROR_CODE);
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/home/api/HomeController.java
+++ b/src/main/java/com/promesa/promesa/domain/home/api/HomeController.java
@@ -1,6 +1,5 @@
 package com.promesa.promesa.domain.home.api;
 
-import com.promesa.promesa.common.config.S3.ImageUrlDto;
 import com.promesa.promesa.domain.home.application.HomeService;
 import com.promesa.promesa.domain.home.dto.BrandInfoResponse;
 import com.promesa.promesa.domain.home.dto.ItemPreviewResponse;
@@ -21,7 +20,7 @@ public class HomeController {
 
     @GetMapping("/brand-info")
     public ResponseEntity<BrandInfoResponse> getBrandInfo() {
-        return ResponseEntity.ok(BrandInfoResponse.INFO);
+        return ResponseEntity.ok(homeService.getBrandInfo());
     }
 
     @GetMapping("/exhibitions/{exhibitionId}/items")

--- a/src/main/java/com/promesa/promesa/domain/home/application/HomeService.java
+++ b/src/main/java/com/promesa/promesa/domain/home/application/HomeService.java
@@ -1,7 +1,9 @@
 package com.promesa.promesa.domain.home.application;
 
+import com.promesa.promesa.common.application.S3Service;
 import com.promesa.promesa.common.query.ItemQueryRepository;
 import com.promesa.promesa.domain.home.dao.ExhibitionRepository;
+import com.promesa.promesa.domain.home.dto.BrandInfoResponse;
 import com.promesa.promesa.domain.home.dto.ItemPreviewResponse;
 import com.promesa.promesa.domain.home.exception.ExhibitionNotFoundException;
 import com.promesa.promesa.domain.item.domain.Exhibition;
@@ -19,6 +21,24 @@ public class HomeService {
     private final ItemQueryRepository itemQueryRepository;
     private final ExhibitionRepository exhibitionRepository;
     private final MemberRepository memberRepository;
+
+    private final S3Service s3Service;
+
+    private static final String BUCKET = "ceos-promesa";
+    private static final String MAIN_IMAGE = "brand-info/mainImage.png";
+    private static final String LEFT_IMAGE = "brand-info/leftImage.png";
+    private static final String RIGHT_IMAGE = "brand-info/rightImage.png";
+
+    /**
+     * 메인 화면에서 브랜드 정보 반환
+     * @return
+     */
+    public BrandInfoResponse getBrandInfo() {
+        String mainUrl = s3Service.createPresignedGetUrl(BUCKET, MAIN_IMAGE);
+        String leftUrl = s3Service.createPresignedGetUrl(BUCKET, LEFT_IMAGE);
+        String rightUrl = s3Service.createPresignedGetUrl(BUCKET, RIGHT_IMAGE);
+        return BrandInfoResponse.of(mainUrl, leftUrl, rightUrl);
+    }
 
     public List<ItemPreviewResponse> getExhibitionItems(Long memberId, Long exhibitionId) {
         // 기획전 존재 여부 검증

--- a/src/main/java/com/promesa/promesa/domain/home/dto/BrandInfoResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/home/dto/BrandInfoResponse.java
@@ -6,16 +6,17 @@ public record BrandInfoResponse(
         String rightImageUrl,
         String brandStory
 ) {
-    public static final BrandInfoResponse INFO = new BrandInfoResponse(
-            "https://ceos-promesa.s3.ap-northeast-2.amazonaws.com/brand-info/mainImage.png",
-            "https://ceos-promesa.s3.ap-northeast-2.amazonaws.com/brand-info/mainImage.png",
-            "https://ceos-promesa.s3.ap-northeast-2.amazonaws.com/brand-info/mainImage.png",
-            "프로메사는 숨겨진 신예 작가들을 발굴하고 \n" +
-                    "작품의 전시와 거래를 돕는 플랫폼입니다.\n" +
-                    "\n" +
-                    "도예를 전공하는 학생, 작품은 있지만 판매에 미숙한 작가, \n" +
-                    "유일무이한 오브제로 일상에 가치를 더하고 싶은 소비자까지.\n" +
-                    "저희 프로메사는 도예를 사랑하는 모두를 위해\n" +
-                    "열정을 다하겠습니다."
-    );
+    private static final String BRAND_STORY = """
+        팀 프로메사는 아직 주목받지 못한 신예 작가들을 발굴하고 
+        플랫폼을 통해 작품의 전시와 거래를 돕습니다.
+
+        도예를 전공하는 학생, 작품은 있지만 판매에 미숙한 작가, 
+        유일무이한 오브제로 일상에 가치를 더하고 싶은 소비자까지.
+        저희 프로메사는 도예를 사랑하는 모두를 위해
+        열정을 다하겠습니다.
+        """;
+
+    public static BrandInfoResponse of(String mainUrl, String leftUrl, String rightUrl) {
+        return new BrandInfoResponse(mainUrl, leftUrl, rightUrl, BRAND_STORY);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   config:
     import: optional:file:.env[.properties]
-  profiles:
-    active: local
 
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,8 @@ logging:
 
 server:
   port: 8081
+
+aws:
+  s3:
+    presigned:
+      expire-minutes: 15


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #36 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 기존 brand-info API에서 반환하던 이미지 URL을 퍼블릭 url에서 presignedURL로 변경했습니다. 

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
- s3에 홈화면 이미지를 업로드 할 때, 폴더 `/brand-info`에 업로드해야 하며 파일명은 다음 3개로 고정되어 있습니다.
    - `mainImage`, `leftImage`, `rightImage`
- 키 값이 바뀌지 않기 위함입니다!

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
