### PR TITLE
feat: s3 이미지 업로드 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/promesa/promesa/common/application/S3Service.java
+++ b/src/main/java/com/promesa/promesa/common/application/S3Service.java
@@ -1,6 +1,7 @@
 package com.promesa.promesa.common.application;
 
 import com.promesa.promesa.common.consts.ImageType;
+import com.promesa.promesa.common.dto.s3.PresignedUrlResponse;
 import com.promesa.promesa.common.exception.InternalServerError;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,7 +62,13 @@ public class S3Service {
         }
     }
 
-    public List<String> createPresignedPutUrl(String bucketName, ImageType imageType, Long referenceId, List<String> fileNames, Map<String, String> metadata) {
+    public List<PresignedUrlResponse> createPresignedPutUrl(
+            String bucketName,
+            ImageType imageType,
+            Long referenceId,
+            List<String> fileNames,
+            Map<String, String> metadata
+    ) {
         try {
             return fileNames.stream()
                     .map(originalFileName -> {
@@ -82,7 +89,7 @@ public class S3Service {
                             PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
                             log.info("Presigned URL 생성: {}", presignedRequest.url());
 
-                            return presignedRequest.url().toExternalForm();
+                            return new PresignedUrlResponse(key, presignedRequest.url().toExternalForm());
                         } catch (Exception e) {
                             log.error("Presigned URL 생성 실패", e);
                             throw InternalServerError.EXCEPTION;

--- a/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
+++ b/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/actuator/**",
                                 "/", "/login", "/signup",
-                                "/brand-info", "/categories/**", "exhibitions/**",
+                                "/brand-info", "/categories/**", "exhibitions/**","",
                                 "/index.html", "/static/**", "/favicon.ico",
                                 "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/h2-console/**"
                         ).permitAll()                        // 위 경로는 인증 없이 접근 허용

--- a/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
+++ b/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/actuator/**",
                                 "/", "/login", "/signup",
-                                "/brand-info", "/categories/**", "exhibitions/**","/review-images/presigned-url",
+                                "/brand-info", "/categories/**", "exhibitions/**","/review-images/**",
                                 "/index.html", "/static/**", "/favicon.ico",
                                 "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/h2-console/**"
                         ).permitAll()                        // 위 경로는 인증 없이 접근 허용

--- a/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
+++ b/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/actuator/**",
                                 "/", "/login", "/signup",
-                                "/brand-info", "/categories/**", "exhibitions/**","",
+                                "/brand-info", "/categories/**", "exhibitions/**","/review-images/presigned-url",
                                 "/index.html", "/static/**", "/favicon.ico",
                                 "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/h2-console/**"
                         ).permitAll()                        // 위 경로는 인증 없이 접근 허용

--- a/src/main/java/com/promesa/promesa/common/consts/ImageType.java
+++ b/src/main/java/com/promesa/promesa/common/consts/ImageType.java
@@ -1,0 +1,7 @@
+package com.promesa.promesa.common.consts;
+
+public enum ImageType {
+    REVIEW,      // 리뷰 이미지
+    PROFILE,     // 프로필 이미지
+    ITEM,        // 작품 이미지
+}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
@@ -1,9 +1,13 @@
 package com.promesa.promesa.common.dto.s3;
 
+import com.promesa.promesa.common.consts.ImageType;
+
 import java.util.List;
 import java.util.Map;
 
 public record PresignedUrlRequest (
-  List<String> keyNames,
-  Map<String, String> metadata
+        ImageType imageType,
+        Long referenceId,
+        List<String> fileNames,
+        Map<String, String> metadata
 ){}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
@@ -1,0 +1,8 @@
+package com.promesa.promesa.common.dto.s3;
+
+import java.util.Map;
+
+public record PresignedUrlRequest (
+  String keyName,
+  Map<String, String> metadata
+){}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
@@ -1,8 +1,9 @@
 package com.promesa.promesa.common.dto.s3;
 
+import java.util.List;
 import java.util.Map;
 
 public record PresignedUrlRequest (
-  String keyName,
+  List<String> keyNames,
   Map<String, String> metadata
 ){}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlResponse.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlResponse.java
@@ -3,5 +3,6 @@ package com.promesa.promesa.common.dto.s3;
 import java.util.List;
 
 public record PresignedUrlResponse (
-        List<String> presignedUrls
+        String key,
+        String url
 ){}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlResponse.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlResponse.java
@@ -1,5 +1,7 @@
 package com.promesa.promesa.common.dto.s3;
 
+import java.util.List;
+
 public record PresignedUrlResponse (
-        String url
+        List<String> presignedUrls
 ){}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlResponse.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlResponse.java
@@ -1,0 +1,5 @@
+package com.promesa.promesa.common.dto.s3;
+
+public record PresignedUrlResponse (
+        String url
+){}

--- a/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
+++ b/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
@@ -1,0 +1,24 @@
+package com.promesa.promesa.domain.review.api;
+
+import com.promesa.promesa.common.dto.s3.PresignedUrlRequest;
+import com.promesa.promesa.common.dto.s3.PresignedUrlResponse;
+import com.promesa.promesa.domain.review.application.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/review-images/presigned-url")
+    public ResponseEntity<List<PresignedUrlResponse>> getPresignedPutUrls(@RequestBody PresignedUrlRequest request) {
+        return ResponseEntity.ok(reviewService.getPresignedPutUrls(request));
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
+++ b/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
@@ -1,13 +1,12 @@
 package com.promesa.promesa.domain.review.api;
 
+import com.promesa.promesa.common.application.S3Service;
 import com.promesa.promesa.common.dto.s3.PresignedUrlRequest;
 import com.promesa.promesa.common.dto.s3.PresignedUrlResponse;
 import com.promesa.promesa.domain.review.application.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -16,9 +15,18 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final S3Service s3Service;
 
     @PostMapping("/review-images/presigned-url")
     public ResponseEntity<List<PresignedUrlResponse>> getPresignedPutUrls(@RequestBody PresignedUrlRequest request) {
         return ResponseEntity.ok(reviewService.getPresignedPutUrls(request));
+    }
+
+    @DeleteMapping("/review-images")
+    public ResponseEntity<Void> deleteReviewImage(
+            @RequestParam String key
+    ){
+        reviewService.deleteReviewImage(key);
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/review/application/ReviewService.java
+++ b/src/main/java/com/promesa/promesa/domain/review/application/ReviewService.java
@@ -1,0 +1,26 @@
+package com.promesa.promesa.domain.review.application;
+
+import com.promesa.promesa.common.application.S3Service;
+import com.promesa.promesa.common.dto.s3.PresignedUrlRequest;
+import com.promesa.promesa.common.dto.s3.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final S3Service s3Service;
+    private static final String BUCKET = "ceos-promesa";
+
+    public List<PresignedUrlResponse> getPresignedPutUrls(PresignedUrlRequest request) {
+        return s3Service.createPresignedPutUrl(
+                BUCKET,
+                request.imageType(),
+                request.referenceId(),
+                request.fileNames(),
+                request.metadata()
+        );
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/review/application/ReviewService.java
+++ b/src/main/java/com/promesa/promesa/domain/review/application/ReviewService.java
@@ -23,4 +23,8 @@ public class ReviewService {
                 request.metadata()
         );
     }
+
+    public void deleteReviewImage(String key) {
+        s3Service.deleteObject(BUCKET, key);
+    }
 }


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #38 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 프론트에서 이미지 업로드 요청 시 업로드용 Presigned Url 응답 반환 구현 : `/review-images/presigned-url`
- s3 버킷의 이미지 삭제 기능 구현 : `/review-images?key={keyName}`

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
- **s3 버킷에서 이미지 삭제 시, 파라미터로 넘겨받은 키(key)값이 존재하지 않더라고 에러를 띄우지 않습니다!** 해당 내용은 공식문서에 따른 `deleteObject` 메서드에 명시되어 있습니다.
> “If the object does not exist, Amazon S3 does not return an error response.”

- 노션 api 명세서에 프론트와 협업 시 참고해야할 내용 적어뒀습니다!
   - [리뷰 등록](https://www.notion.so/1e71538d37f78042b4b8c75dc15c64db) : 리뷰 등록 흐름에 대해서 작성
   - [리뷰 이미지 추가](https://www.notion.so/1e71538d37f780279049f7cef2112968)
   - [리뷰 이미지 삭제](https://www.notion.so/1e71538d37f7809d9b69db909d2ae32e)

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
