### PR TITLE
refactor: 카테고리 상품 조회 및 기획전 상품 조회 시 이미지를 presigned url로 수정

### DIFF
--- a/src/main/java/com/promesa/promesa/common/query/ItemQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/common/query/ItemQueryRepository.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.promesa.promesa.domain.artist.domain.QArtist.artist;
-import static com.promesa.promesa.domain.image.domain.QItemImage.itemImage;
 import static com.promesa.promesa.domain.item.domain.QExhibitionItem.exhibitionItem;
 import static com.promesa.promesa.domain.item.domain.QItem.item;
+import static com.promesa.promesa.domain.item.domain.QItemImage.itemImage;
 import static com.promesa.promesa.domain.itemCategory.domain.QItemCategory.itemCategory;
 import static com.promesa.promesa.domain.wish.domain.QWish.wish;
 
@@ -38,14 +38,14 @@ public class ItemQueryRepository {
      */
     public List<ItemPreviewResponse> findExhibitionItem(Long memberId, Long exhibitionId) {
         return queryFactory
-                .select(Projections.constructor(ItemPreviewResponse.class,
-                        item.id,
-                        item.name,
-                        item.description,
+                .select(Projections.fields(ItemPreviewResponse.class,
+                        item.id.as("itemId"),
+                        item.name.as("itemName"),
+                        item.description.as("itemDescription"),
                         item.price,
-                        itemImage.imageUrl,
-                        artist.name,
-                        wish.id.isNotNull()
+                        itemImage.imageKey,
+                        artist.name.as("artistName"),
+                        wish.id.isNotNull().as("isWished")
                 ))
                 .from(exhibitionItem)
                 .join(exhibitionItem.item, item)
@@ -70,14 +70,14 @@ public class ItemQueryRepository {
      */
     public Page<ItemPreviewResponse> findCategoryItem(Long memberId, Long categoryId, Pageable pageable) {
         List<ItemPreviewResponse> content = queryFactory
-                .select(Projections.constructor(ItemPreviewResponse.class,
-                        item.id,
-                        item.name,
-                        item.description,
+                .select(Projections.fields(ItemPreviewResponse.class,
+                        item.id.as("itemId"),
+                        item.name.as("itemName"),
+                        item.description.as("itemDescription"),
                         item.price,
-                        itemImage.imageUrl,
-                        artist.name,
-                        wish.id.isNotNull()
+                        itemImage.imageKey,
+                        artist.name.as("artistName"),
+                        wish.id.isNotNull().as("isWished")
                 ))
                 .from(itemCategory)
                 .join(itemCategory.item, item)

--- a/src/main/java/com/promesa/promesa/domain/home/dto/ItemPreviewResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/home/dto/ItemPreviewResponse.java
@@ -1,11 +1,23 @@
 package com.promesa.promesa.domain.home.dto;
 
-public record ItemPreviewResponse(
-        Long itemId,
-        String itemName,
-        String itemDescription,
-        int price,
-        String thumnailUrl,
-        String artistName,
-        boolean isWished
-) {}
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemPreviewResponse {   // ← 반드시 public 으로
+    private Long itemId;
+    private String itemName;
+    private String itemDescription;
+    private int price;
+    private String imageKey;
+    private String imageUrl;
+    private String artistName;
+    private boolean isWished;
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/item/application/ItemService.java
+++ b/src/main/java/com/promesa/promesa/domain/item/application/ItemService.java
@@ -1,13 +1,16 @@
 package com.promesa.promesa.domain.item.application;
 
+import com.promesa.promesa.common.application.S3Service;
 import com.promesa.promesa.common.query.ItemQueryRepository;
 import com.promesa.promesa.domain.category.dao.CategoryRepository;
 import com.promesa.promesa.domain.category.domain.Category;
 import com.promesa.promesa.domain.category.exception.CategoryNotFoundException;
 import com.promesa.promesa.domain.home.dto.ItemPreviewResponse;
+import com.promesa.promesa.domain.item.domain.Item;
 import com.promesa.promesa.domain.member.dao.MemberRepository;
 import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.domain.member.exception.MemberNotFoundException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,11 @@ public class ItemService {
     private final ItemQueryRepository itemQueryRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final S3Service s3Service;
+
+    @Value("${aws.s3.bucket}")  // application.yml 에 정의 필요
+    private String bucketName;
+
 
     public Page<ItemPreviewResponse> findCategoryItem(Long memberId, Long categoryId, Pageable pageable) {
         // 카테고리 존재 여부 검증
@@ -31,6 +39,14 @@ public class ItemService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
 
-        return itemQueryRepository.findCategoryItem(memberId, categoryId, pageable);
+        Page<ItemPreviewResponse> responses = itemQueryRepository.findCategoryItem(memberId, categoryId, pageable);
+        // imageKey → presigned URL 변환
+        responses.forEach(response -> {
+            if (response.getImageKey() != null) {
+                String url = s3Service.createPresignedGetUrl(bucketName, response.getImageKey());
+                response.setImageUrl(url);
+            }
+        });
+        return responses;
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/item/domain/Item.java
+++ b/src/main/java/com/promesa/promesa/domain/item/domain/Item.java
@@ -2,7 +2,6 @@ package com.promesa.promesa.domain.item.domain;
 
 import com.promesa.promesa.common.domain.BaseTimeEntity;
 import com.promesa.promesa.domain.artist.domain.Artist;
-import com.promesa.promesa.domain.image.domain.ItemImage;
 import com.promesa.promesa.domain.itemCategory.domain.ItemCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/promesa/promesa/domain/item/domain/ItemImage.java
+++ b/src/main/java/com/promesa/promesa/domain/item/domain/ItemImage.java
@@ -1,6 +1,5 @@
-package com.promesa.promesa.domain.image.domain;
+package com.promesa.promesa.domain.item.domain;
 
-import com.promesa.promesa.domain.item.domain.Item;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,8 +16,8 @@ public class ItemImage {
     private Long id;
 
     @NotBlank
-    @Column(name = "image_url")
-    private String imageUrl;
+    @Column(name = "item_image_key")
+    private String imageKey;
 
     @NotNull
     private boolean isThumbnail;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -37,18 +37,18 @@ VALUES
     (9, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '투톤 머그', '모던 머그', 11000, 'ON_SALE', 6, 0, 3),
     (10, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '라인 컵', '라인 컵', 12500, 'ON_SALE', 4, 0, 1);
 
-INSERT INTO ITEM_IMAGE (ITEM_IMAGE_ID, IMAGE_URL, IS_THUMBNAIL, ITEM_ID)
+INSERT INTO ITEM_IMAGE (ITEM_IMAGE_ID, ITEM_IMAGE_KEY, IS_THUMBNAIL, ITEM_ID)
 VALUES
-    (1, 'https://example.com/image1.jpg', TRUE, 1),
-    (2, 'https://example.com/image2.jpg', TRUE, 2),
-    (3, 'https://example.com/image3.jpg', TRUE, 3),
-    (4, 'https://example.com/image4.jpg', TRUE, 4),
-    (5, 'https://example.com/image5.jpg', TRUE, 5),
-    (6, 'https://example.com/image6.jpg', TRUE, 6),
-    (7, 'https://example.com/image7.jpg', TRUE, 7),
-    (8, 'https://example.com/image8.jpg', TRUE, 8),
-    (9, 'https://example.com/image9.jpg', TRUE, 9),
-    (10, 'https://example.com/image10.jpg', TRUE, 10);
+    (1, 'image1.jpg', TRUE, 1),
+    (2, 'image2.jpg', TRUE, 2),
+    (3, 'image3.jpg', TRUE, 3),
+    (4, 'image4.jpg', TRUE, 4),
+    (5, 'image5.jpg', TRUE, 5),
+    (6, 'image6.jpg', TRUE, 6),
+    (7, 'image7.jpg', TRUE, 7),
+    (8, 'image8.jpg', TRUE, 8),
+    (9, 'image9.jpg', TRUE, 9),
+    (10, 'image10.jpg', TRUE, 10);
 
 INSERT INTO WISH (WISH_ID, TARGET_ID, TARGET_TYPE, MEMBER_ID)
 VALUES


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #48 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- exhibition과 category를 조회할 때 item의 이미지를 presigned Url로 받아오도록 수정했습니다!

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
