### PR TITLE
feat: 소셜 로그인 성공 시 리다이렉트 처리

### DIFF
--- a/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
+++ b/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
@@ -8,15 +8,19 @@ import com.promesa.promesa.security.jwt.JwtAuthenticationEntryPoint;
 import com.promesa.promesa.security.jwt.JwtAuthenticationFilter;
 import com.promesa.promesa.security.jwt.JwtUtil;
 import com.promesa.promesa.security.oauth.OAuth2SuccessHandler;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
 
 @Configuration
 @EnableWebSecurity
@@ -32,35 +36,83 @@ public class SecurityConfig {
     private final ObjectMapper objectMapper;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, JwtUtil jwtUtil) throws Exception {
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            ClientRegistrationRepository clientRegistrationRepository
+    ) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .logout(logout -> logout.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/review-images/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/reviews/**", "/review-images/**").permitAll()
                         .requestMatchers(
                                 "/actuator/**",
                                 "/", "/login", "/signup",
-                                "/brand-info", "/categories/**", "exhibitions/**","/inquiries/**","/artists/**",
+                                "/brand-info", "/categories/**", "/exhibitions/**", "/inquiries/**", "/artists/**",
                                 "/index.html", "/static/**", "/favicon.ico",
                                 "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/h2-console/**",
                                 "/auth/reissue", "/auth/logout"
-                        ).permitAll()                        // 위 경로는 인증 없이 접근 허용
-                        .requestMatchers("/oauth/loginInfo").authenticated() // 이건 명시적으로 인증 필요
-                        .anyRequest().authenticated()       // 나머지는 모두 인증 필요
+                        ).permitAll()
+                        .requestMatchers("/oauth/loginInfo").authenticated()
+                        .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestResolver(
+                                        customAuthorizationRequestResolver(clientRegistrationRepository)
+                                )
+                        )
                         .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2Service))
                         .successHandler(oAuth2SuccessHandler)
                 );
 
-        http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userDetailsService,objectMapper), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userDetailsService, objectMapper), UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
+    }
+
+    @Bean
+    public OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver(
+            ClientRegistrationRepository repo
+    ) {
+        DefaultOAuth2AuthorizationRequestResolver defaultResolver =
+                new DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization");
+
+        return new OAuth2AuthorizationRequestResolver() {
+            @Override
+            public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+                OAuth2AuthorizationRequest originalRequest = defaultResolver.resolve(request);
+                if (originalRequest == null) return null;
+
+                String stateParam = request.getParameter("state");
+                OAuth2AuthorizationRequest.Builder builder = OAuth2AuthorizationRequest.from(originalRequest);
+
+                if (stateParam != null && !stateParam.isBlank()) {
+                    builder.state(stateParam);
+                }
+
+                return builder.build();
+            }
+
+            @Override
+            public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+                OAuth2AuthorizationRequest originalRequest = defaultResolver.resolve(request, clientRegistrationId);
+                if (originalRequest == null) return null;
+
+                String stateParam = request.getParameter("state");
+                OAuth2AuthorizationRequest.Builder builder = OAuth2AuthorizationRequest.from(originalRequest);
+
+                if (stateParam != null && !stateParam.isBlank()) {
+                    builder.state(stateParam);
+                }
+
+                return builder.build();
+            }
+        };
     }
 }

--- a/src/main/java/com/promesa/promesa/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/promesa/promesa/security/oauth/OAuth2SuccessHandler.java
@@ -79,7 +79,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             URI uri = new URI(baseRedirectUri);
             String host = uri.getHost();
 
-            if (!(host.equals("localhost") || host.equals("ceos-promesa.vercel.app"))) {
+            if (!(host.equals("localhost") || host.equals("ceos-promesa.vercel.app") || host.equals("promesa.co.kr"))) {
                 throw new IllegalArgumentException("허용되지 않은 리다이렉트 base URI: " + baseRedirectUri);
             }
         } catch (URISyntaxException e) {

--- a/src/main/java/com/promesa/promesa/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/promesa/promesa/security/oauth/OAuth2SuccessHandler.java
@@ -79,7 +79,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             URI uri = new URI(baseRedirectUri);
             String host = uri.getHost();
 
-            if (!(host.equals("localhost") || host.equals("promesa.co.kr"))) {
+            if (!(host.equals("localhost") || host.equals("ceos-promesa.vercel.app"))) {
                 throw new IllegalArgumentException("허용되지 않은 리다이렉트 base URI: " + baseRedirectUri);
             }
         } catch (URISyntaxException e) {

--- a/src/main/java/com/promesa/promesa/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/promesa/promesa/security/oauth/OAuth2SuccessHandler.java
@@ -1,6 +1,5 @@
 package com.promesa.promesa.security.oauth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.promesa.promesa.security.jwt.JwtProperties;
 import com.promesa.promesa.security.jwt.JwtUtil;
 import com.promesa.promesa.security.jwt.refresh.RefreshRepository;
@@ -17,7 +16,10 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @Slf4j
@@ -27,7 +29,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtUtil jwtUtil;
     private final RefreshRepository refreshRepository;
-    private final ObjectMapper objectMapper;
     private final JwtProperties jwtProperties;
 
     @Override
@@ -41,39 +42,69 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String provider = oauthToken.getAuthorizedClientRegistrationId(); // ex. "kakao"
         String providerId = extractProviderId(provider, oAuth2User.getAttributes());
 
-        // subject = "kakao:12345"
         String nickname = provider + ":" + providerId;
         String role = "USER";
 
-        // 1. Access Token + Refresh Token 생성
+        // 1. JWT 발급
         String accessToken = jwtUtil.createAccessToken(nickname, role);
         String refreshToken = jwtUtil.createRefreshToken(nickname, role);
 
-        // 2. Refresh Token Redis 저장
+        // 2. Redis에 Refresh Token 저장
         refreshRepository.save(refreshToken, nickname, jwtProperties.getRefreshTokenExpiration());
 
-        // 3. Refresh Token 쿠키에 저장 (HttpOnly)
+        // 3. Refresh Token을 HttpOnly 쿠키에 저장
         Cookie refreshCookie = new Cookie("refresh", refreshToken);
         refreshCookie.setHttpOnly(true);
-        refreshCookie.setSecure(true); // 로컬 개발 시 false
+        refreshCookie.setSecure(!isLocal(request)); // 로컬이면 false
         refreshCookie.setPath("/");
         refreshCookie.setMaxAge((int)(jwtProperties.getRefreshTokenExpiration() / 1000));
         response.addCookie(refreshCookie);
 
-        // 4. 응답 전송 (accessToken은 헤더 + JSON 바디)
-        response.setHeader("Authorization", "Bearer " + accessToken);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
+        // 4. AccessToken도 쿠키로 내려줌
+        Cookie accessCookie = new Cookie("access", accessToken);
+        accessCookie.setHttpOnly(true);
+        accessCookie.setSecure(!isLocal(request));
+        accessCookie.setPath("/");
+        accessCookie.setMaxAge((int)(jwtProperties.getAccessTokenExpiration() / 1000));
+        response.addCookie(accessCookie);
 
-        Map<String, String> body = new HashMap<>();
-        body.put("accessToken", accessToken);
-        response.getWriter().write(objectMapper.writeValueAsString(body));
+        // 5. 프론트 base URI 꺼내기 (state 파라미터에서)
+        String baseRedirectUri = request.getParameter("state");
+        if (baseRedirectUri == null || baseRedirectUri.isBlank()) {
+            baseRedirectUri = "http://localhost:3000";
+        }
+
+        // 6. 보안상 허용된 base 주소만 허용
+        try {
+            URI uri = new URI(baseRedirectUri);
+            String host = uri.getHost();
+
+            if (!(host.equals("localhost") || host.equals("promesa.co.kr"))) {
+                throw new IllegalArgumentException("허용되지 않은 리다이렉트 base URI: " + baseRedirectUri);
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("리다이렉트 URI 파싱 실패: " + baseRedirectUri);
+        }
+
+        // 7. base URI에 무조건 /login/success 붙여서 accessToken 전달
+        String finalRedirect = baseRedirectUri + "/login/success?accessToken=" + accessToken;
+
+        log.info("✅ OAuth2 Login Success: {}", nickname);
+        log.info("🔑 AccessToken issued, redirecting to {}", finalRedirect);
+
+        response.sendRedirect(finalRedirect);
     }
 
     private String extractProviderId(String provider, Map<String, Object> attributes) {
         if ("kakao".equals(provider)) {
-            return String.valueOf(attributes.get("id"));
+            return String.valueOf(attributes.get("id")); // 카카오의 고유 ID는 "id" 필드
         }
-        throw new IllegalArgumentException("Unsupported provider: " + provider);
+        // TODO: 구글, 네이버 등 다른 provider 추가 시 확장
+        throw new IllegalArgumentException("지원하지 않는 provider: " + provider);
+    }
+
+    private boolean isLocal(HttpServletRequest request) {
+        String host = request.getServerName();
+        return host.contains("localhost") || host.contains("127.0.0.1");
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #{$이슈 번호}

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 리다이렉트 URI를 프론트에서 state 파라미터로 전달받아 처리
  - 요청 주소
    - http://localhost:8081/oauth2/authorization/kakao?state=http://localhost:3000
      state 값이 없을 경우 fallback URI로 http://localhost:3000 사용
    - https://ceos-promesa.vercel.app /oauth2/authorization/kakao?state=https://ceos-promesa.vercel.app 
    - https://promesa.co.kr/oauth2/authorization/kakao?state=https://promesa.co.kr
- 보안상 허용된 리다이렉트 URI만 허용하도록 검증 추가
- 최종 리다이렉트 주소 구성
  - 형식:
  `{state}/login/success?accessToken={accessToken}`
  - 예시:
  `http://localhost:3000/login/success?accessToken=eyJ...`

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
