### PR TITLE
feat: 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/com/promesa/promesa/common/config/QueryDslConfig.java
+++ b/src/main/java/com/promesa/promesa/common/config/QueryDslConfig.java
@@ -1,5 +1,6 @@
 package com.promesa.promesa.common.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -14,6 +15,6 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
+++ b/src/main/java/com/promesa/promesa/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .logout(logout -> logout.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/items/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/review-images/**").permitAll()
                         .requestMatchers(
                                 "/actuator/**",

--- a/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
+++ b/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
@@ -13,6 +13,9 @@ import com.promesa.promesa.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -80,5 +83,15 @@ public class ReviewController {
         Member member = (user != null) ? user.getMember() : null;
         ReviewResponse response = reviewService.updateReview(request, itemId, reviewId, member);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/items/{itemId}/reviews")
+    @Operation(summary = "리뷰 조회")
+    public ResponseEntity<Page<ReviewResponse>> getReviews(
+            @PathVariable Long itemId,
+            @ParameterObject Pageable pageable
+    ){
+        Page<ReviewResponse> responses = reviewService.getReviews(itemId, pageable);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/review/domain/Review.java
+++ b/src/main/java/com/promesa/promesa/domain/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.promesa.promesa.domain.review.domain;
 
+import com.promesa.promesa.common.domain.BaseTimeEntity;
 import com.promesa.promesa.domain.item.domain.Item;
 import com.promesa.promesa.domain.member.domain.Member;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import java.util.List;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Review {
+public class Review extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "review_id")
     private Long id;

--- a/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewQueryDto.java
+++ b/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewQueryDto.java
@@ -1,0 +1,27 @@
+package com.promesa.promesa.domain.review.dto.response;
+
+import com.promesa.promesa.domain.review.domain.Review;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ReviewQueryDto {
+    private Long reviewId;
+    private String content;
+    private Long itemId;
+    private Long reviewerId;
+    private int rating;
+    private List<String> reviewImages;
+
+    public ReviewQueryDto(Long reviewId, String content, Long itemId, Long reviewerId, int rating, List<String> reviewImages) {
+        this.reviewId = reviewId;
+        this.content = content;
+        this.itemId = itemId;
+        this.reviewerId = reviewerId;
+        this.rating = rating;
+        this.reviewImages = reviewImages;
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewResponse.java
@@ -1,25 +1,41 @@
 package com.promesa.promesa.domain.review.dto.response;
 
 import com.promesa.promesa.domain.review.domain.Review;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-public record ReviewResponse(
-        Long reviewId,
-        String content,
-        Long itemId,
-        Long reviewerId,
-        int rating,
-        List<String> reviewImages
-){
+@Getter
+@Builder
+public class ReviewResponse {
+    private final Long reviewId;
+    private final String content;
+    private final Long itemId;
+    private final Long reviewerId;
+    private final int rating;
+    private final List<String> reviewImages;
+
     public static ReviewResponse from(Review review, List<String> imageKeys) {
-        return new ReviewResponse(
-                review.getId(),
-                review.getContent(),
-                review.getItem().getId(),
-                review.getMember().getId(),
-                review.getRating(),
-                imageKeys
-        );
+        return ReviewResponse.builder()
+                .reviewId(review.getId())
+                .content(review.getContent())
+                .itemId(review.getItem().getId())
+                .reviewerId(review.getMember().getId())
+                .rating(review.getRating())
+                .reviewImages(imageKeys)
+                .build();
+    }
+
+    public static ReviewResponse from(ReviewQueryDto dto, List<String> imageKeys) {
+        return ReviewResponse.builder()
+                .reviewId(dto.getReviewId())
+                .content(dto.getContent())
+                .itemId(dto.getItemId())
+                .reviewerId(dto.getReviewerId())
+                .rating(dto.getRating())
+                .reviewImages(imageKeys)
+                .build();
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewResponse.java
@@ -3,7 +3,6 @@ package com.promesa.promesa.domain.review.dto.response;
 import com.promesa.promesa.domain.review.domain.Review;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 

--- a/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
@@ -1,0 +1,78 @@
+package com.promesa.promesa.domain.review.query;
+
+import com.promesa.promesa.domain.review.dto.response.ReviewQueryDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.promesa.promesa.domain.review.domain.QReview.review;
+import static com.promesa.promesa.domain.review.domain.QReviewImage.reviewImage;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<ReviewQueryDto> findAllReviews(Long itemId, Pageable pageable) {
+        List<Long> reviewIds = queryFactory
+                .select(review.id)
+                .from(review)
+                .where(review.item.id.eq(itemId))
+                .orderBy(
+                        review.rating.desc(),
+                        Expressions.stringTemplate("char_length({0})", review.content).desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (reviewIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        Map<Long, Integer> idOrderMap = new HashMap<>();
+        for (int i = 0; i < reviewIds.size(); i++) {
+            idOrderMap.put(reviewIds.get(i), i);
+        }
+
+        List<ReviewQueryDto> results = queryFactory
+                .from(review)
+                .leftJoin(review.reviewImages, reviewImage)
+                .where(review.id.in(reviewIds))
+                .transform(
+                        groupBy(review.id).list(
+                                Projections.fields(ReviewQueryDto.class,
+                                        review.id.as("reviewId"),
+                                        review.content.as("content"),
+                                        review.item.id.as("itemId"),
+                                        review.member.id.as("reviewerId"),
+                                        review.rating.as("rating"),
+                                        list(reviewImage.key).as("reviewImages")
+                                )
+                        )
+                );
+
+        results.sort(Comparator.comparingInt(dto -> idOrderMap.get(dto.getReviewId())));
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(review.count())
+                .from(review)
+                .where(review.item.id.eq(itemId));
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
@@ -33,8 +33,8 @@ public class ReviewQueryRepository {
                 .from(review)
                 .where(review.item.id.eq(itemId))
                 .orderBy(
-                        review.rating.desc(),
-                        Expressions.stringTemplate("char_length({0})", review.content).desc()
+                        review.rating.desc(),   // 리뷰 높은 순
+                        Expressions.stringTemplate("char_length({0})", review.content).desc()   // 글자 수 많은 순
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -46,7 +46,7 @@ public class ReviewQueryRepository {
 
         Map<Long, Integer> idOrderMap = new HashMap<>();
         for (int i = 0; i < reviewIds.size(); i++) {
-            idOrderMap.put(reviewIds.get(i), i);
+            idOrderMap.put(reviewIds.get(i), i);    // 리뷰 아이디, 정렬된 순서
         }
 
         List<ReviewQueryDto> results = queryFactory
@@ -66,7 +66,7 @@ public class ReviewQueryRepository {
                         )
                 );
 
-        results.sort(Comparator.comparingInt(dto -> idOrderMap.get(dto.getReviewId())));
+        results.sort(Comparator.comparingInt(dto -> idOrderMap.get(dto.getReviewId())));        // 정렬 순서로 복원
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(review.count())

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -3,7 +3,8 @@ VALUES (1, '김회원', 'kakao', '1234'),
        (2, '원회원', 'kakao', '5678'),
        (3, '김작가', 'kakao', '1011'),
        (4, '이작가', 'kakao', '1213'),
-       (5, '박작가', 'kakao', '1415')
+       (5, '박작가', 'kakao', '1415'),
+       (6, '남궁회원', 'kakao', '1617')
 ;
 
 ALTER TABLE MEMBER ALTER COLUMN MEMBER_ID RESTART WITH 7;
@@ -582,3 +583,14 @@ VALUES
 INSERT INTO INQUIRY (INQUIRY_ID, QUESTION, ANSWER, ARTIST_ID)
 VALUES (1, '배송은 얼마나 걸리나요?', '약 3~5일 소요됩니다.', 1),
        (2, '포장 상태는 어떤가요?', NULL, 1);
+
+INSERT INTO REVIEW (REVIEW_ID, ITEM_ID, MEMBER_ID, RATING, CONTENT)
+VALUES (1, 1, 1, 1, '도자기가 다 깨져서 왔어요ㅠㅠㅠㅠㅠㅠㅠㅠㅠ'),
+       (2, 1, 2, 5, '완전 굿굿굿굿짱짱짱짱이에욤'),
+       (3, 1, 6, 5, '너무너무 마음에 들어요. 제가 찾아 헤맨 작품입니다.')
+;
+
+INSERT INTO REVIEW_IMAGE (REVIEW_IMAGE_ID, REVIEW_ID, IMAGE_KEY)
+VALUES (1, 1, 'member/1/review/1/불만.jpg'),
+       (2, 3, 'member/6/review/1/최고.jpg'),
+       (3, 3, 'member/6/review/1/엄지.jpg');


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #67 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 리뷰를 정렬하여 가져옵니다. 
- 조회할 페이지와 페이지의 사이즈를 지정할 수 있습니다. 

**구현 방식**
- QueryDsl 을 통해 구현했습니다. 
- 한 리뷰에 이미지가 여러 장인 경우, 하나의 해당 리뷰가 이미지의 개수만큼 호출되는 문제를 해결하기 위해 groupBy를 사용했습니다. .
- groupBy와 페이징, 정렬은 사용이 동시에 불가능해 쿼리를 2번으로 해결했습니다. 
    1. 찾고자하는 itemId를 가지는 리뷰 id를 가져와서 정렬하고 정렬된 id 값을 저장하기
    2. reviewId의 reviewImages를 가져오기
    3. reviewId와 reviewImages를 매핑하고 다시 정렬하기

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
**리뷰 정렬 기준:**
1. 별점 높은 순
4. 별점이 같을 경우 글자 수 많은 순서로

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
