### PR TITLE
refactor: 이미지 업로드 시 키 생성 로직 수정

### DIFF
--- a/src/main/java/com/promesa/promesa/common/consts/ImageType.java
+++ b/src/main/java/com/promesa/promesa/common/consts/ImageType.java
@@ -1,7 +1,12 @@
 package com.promesa.promesa.common.consts;
 
 public enum ImageType {
-    REVIEW,      // 리뷰 이미지
-    PROFILE,     // 프로필 이미지
-    ITEM,        // 작품 이미지
+    ITEM("item"),
+    ARTIST("artist"),
+    MEMBER("member"),
+    EXHIBITION("exhibition");
+
+    private final String path;
+    ImageType(String path) { this.path = path; }
+    public String getPath() { return path; }
 }

--- a/src/main/java/com/promesa/promesa/common/consts/SubType.java
+++ b/src/main/java/com/promesa/promesa/common/consts/SubType.java
@@ -1,0 +1,14 @@
+package com.promesa.promesa.common.consts;
+
+public enum SubType {
+    MAIN("main"),
+    DETAIL("detail"),
+    PROFILE("profile"),
+    REVIEW("review"),
+    THUMBNAIL("thumbnail"),
+    PROMOTION("promotion");
+
+    private final String path;
+    SubType(String path) { this.path = path; }
+    public String getPath() { return path; }
+}

--- a/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
+++ b/src/main/java/com/promesa/promesa/common/dto/s3/PresignedUrlRequest.java
@@ -1,6 +1,7 @@
 package com.promesa.promesa.common.dto.s3;
 
 import com.promesa.promesa.common.consts.ImageType;
+import com.promesa.promesa.common.consts.SubType;
 
 import java.util.List;
 import java.util.Map;
@@ -8,6 +9,8 @@ import java.util.Map;
 public record PresignedUrlRequest (
         ImageType imageType,
         Long referenceId,
+        SubType subType,
+        Long subReferenceId,
         List<String> fileNames,
         Map<String, String> metadata
 ){}

--- a/src/main/java/com/promesa/promesa/domain/review/application/ReviewImageService.java
+++ b/src/main/java/com/promesa/promesa/domain/review/application/ReviewImageService.java
@@ -25,10 +25,13 @@ public class ReviewImageService {
      * @return
      */
     public List<PresignedUrlResponse> getPresignedPutUrls(PresignedUrlRequest request) {
+
         return s3Service.createPresignedPutUrl(
                 bucketName,
                 request.imageType(),
                 request.referenceId(),
+                request.subType(),
+                request.subReferenceId(),
                 request.fileNames(),
                 request.metadata()
         );


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #111 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- s3 버킷의 폴더 구조에 따라 이미지를 업로드할 때 발급받는 key 생성 로직을 수정했습니다. 
- 업로드한 파일명에 `/` 또는 `\`가 포함되어 있을 경우`_`로 변환했습니다. 
    - 예시 : `pink/cup.png` -> `pink_cup.png`

#### 🔸 경로 분류
- 1차 분류 구조 : imageType, referenceId
- 2차 분류 구조 : subType, subReferenceId

#### 🔸 가능한 조합
- ITEM - referenceId - MAIN - null
- ITEM - referenceId - DETAIL - null
- ARTIST - referenceId - PROFILE - null
- MEMBER - referenceId - REVIEW - subReferenceId
- EXHIBITION - referenceId - THUMNAIL - null
- EXHIBITION - referenceId - PROMOTION - null

#### 🔸 예시 상황
**Request**
```
{
  "imageType": "ITEM",
  "referenceId": 1,
  "subType": "MAIN",
  "subReferenceId": null,
  "fileNames": [
    "pink/cup"
  ]
}
```

**Response**
```
{
  "success": true,
  "status": 200,
  "timeStamp": "2025-07-18T16:24:13.1215505",
  "data": [
    {
      "key": "item/1/main/5aa78672-f6ff-459a-864d-94679e1e0d45-pink_cup",
      "url": "https://ceos-promesa.s3.ap-northeast-2.amazonaws.com/item/1/main/5aa78672-f6ff-459a-864d-94679e1e0d45-pink_cup?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250718T072413Z&X-Amz-SignedHeaders=host&X-Amz-Expires=899&X-Amz-Credential=AKIA6CGYKEJU2OIBLQSX%2F20250718%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=4adaa6178090a8e3f0c84604186a48d69082b12d4ecd5563053d4187790bdfb3"
    }
  ]
}
```

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
[Request 정리](https://www.notion.so/1e71538d37f780279049f7cef2112968?source=copy_link)

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
s3버킷 폴더 구조 참고 : #58 