### PR TITLE
feat: 기획전 상태별 목록 조회

### DIFF
--- a/src/main/java/com/promesa/promesa/PromesaApplication.java
+++ b/src/main/java/com/promesa/promesa/PromesaApplication.java
@@ -5,7 +5,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableConfigurationProperties(JwtProperties.class)

--- a/src/main/java/com/promesa/promesa/domain/artist/api/ArtistController.java
+++ b/src/main/java/com/promesa/promesa/domain/artist/api/ArtistController.java
@@ -8,7 +8,7 @@ import com.promesa.promesa.domain.item.application.ItemService;
 import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.security.jwt.CustomUserDetails;
 import com.promesa.promesa.domain.exhibition.application.ExhibitionService;
-import com.promesa.promesa.domain.exhibition.dto.response.ExhibitionResponse;
+import com.promesa.promesa.domain.exhibition.dto.response.ExhibitionSummary;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -39,7 +39,7 @@ public class ArtistController {
 
     @GetMapping("/{artistId}/exhibitions")
     @Operation(summary = "작가가 참여한 전시 목록 조회")
-    public ResponseEntity<List<ExhibitionResponse>> getExhibitionsByArtist(@PathVariable Long artistId) {
+    public ResponseEntity<List<ExhibitionSummary>> getExhibitionsByArtist(@PathVariable Long artistId) {
         return ResponseEntity.ok(exhibitionService.getExhibitionsByArtist(artistId));
     }
 

--- a/src/main/java/com/promesa/promesa/domain/exhibition/api/ExhibitionController.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/api/ExhibitionController.java
@@ -1,7 +1,9 @@
 package com.promesa.promesa.domain.exhibition.api;
 
 import com.promesa.promesa.domain.exhibition.application.ExhibitionService;
+import com.promesa.promesa.domain.exhibition.domain.ExhibitionStatus;
 import com.promesa.promesa.domain.exhibition.dto.response.ExhibitionResponse;
+import com.promesa.promesa.domain.exhibition.dto.response.ExhibitionSummary;
 import com.promesa.promesa.domain.home.dto.response.ItemPreviewResponse;
 import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.security.jwt.CustomUserDetails;
@@ -30,10 +32,21 @@ public class ExhibitionController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping
+    @GetMapping("/ongoing")
     @Operation(summary = "진행 중인 전시 목록 조회")
-    public ResponseEntity<List<ExhibitionResponse>> getOngoingExhibition() {
-        List<ExhibitionResponse> response = exhibitionService.getOngoingExhibitions();
+    public ResponseEntity<List<ExhibitionSummary>> getOngoingExhibition() {
+        List<ExhibitionSummary> response = exhibitionService.getOngoingExhibitions();
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "전시 상태 별 전시 목록 조회")
+    public ResponseEntity<List<ExhibitionResponse>> getExhibition(
+            @RequestParam(required = false) ExhibitionStatus status,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Member member = (user != null) ? user.getMember() : null;
+        List<ExhibitionResponse> responses = exhibitionService.getExhibitions(status, member);
+        return  ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/exhibition/application/ExhibitionService.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/application/ExhibitionService.java
@@ -92,13 +92,7 @@ public class ExhibitionService {
     }
 
     public List<ExhibitionResponse> getExhibitions(ExhibitionStatus status, Member member) {
-        List<Exhibition> exhibitions;
-        if (status == null) {   // ALL
-            exhibitions = exhibitionRepository.findAll();
-        }
-        else {
-            exhibitions = exhibitionRepository.findAllByStatus(status);
-        }
+        List<Exhibition> exhibitions = exhibitionQueryRepository.findByStatusOrderByStartDateDesc(status);
         List<ExhibitionResponse> responses = new ArrayList<>();
 
         for (Exhibition exhibition : exhibitions) {

--- a/src/main/java/com/promesa/promesa/domain/exhibition/application/ExhibitionStatusScheduler.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/application/ExhibitionStatusScheduler.java
@@ -1,0 +1,41 @@
+package com.promesa.promesa.domain.exhibition.application;
+
+import com.promesa.promesa.domain.exhibition.dao.ExhibitionRepository;
+import com.promesa.promesa.domain.exhibition.domain.Exhibition;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.promesa.promesa.domain.exhibition.domain.ExhibitionStatus.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExhibitionStatusScheduler {
+
+    private final ExhibitionRepository exhibitionRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")   // 매일 오전 12시
+    public void updateExhibitionStatus() {
+        List<Exhibition> exhibitions = exhibitionRepository.findAllByStatusIn(List.of(UPCOMING, ONGOING));
+        LocalDate today = LocalDate.now();
+
+        for (Exhibition exhibition : exhibitions) {
+            if (exhibition.getStatus() == UPCOMING && today.isAfter(exhibition.getStartDate())) {
+                if (exhibition.getEndDate() == null) exhibition.setStatus(PERMANENT);
+                else exhibition.setStatus(ONGOING);
+            }
+            else if (exhibition.getStatus() == ONGOING && today.isAfter(exhibition.getEndDate())) {
+                exhibition.setStatus(PAST);
+            }
+        }
+
+        log.info("Exhibition 상태 업데이트 완료 (총 {}건)", exhibitions.size());
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/exhibition/dao/ExhibitionRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/dao/ExhibitionRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface ExhibitionRepository extends JpaRepository<Exhibition, Long> {
     List<Exhibition> findAllByStatus(ExhibitionStatus status);
+
+    List<Exhibition> findAllByStatusIn(List<ExhibitionStatus> statuses);
 }

--- a/src/main/java/com/promesa/promesa/domain/exhibition/domain/Exhibition.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/domain/Exhibition.java
@@ -50,4 +50,8 @@ public class Exhibition extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL)
     private List<ExhibitionArtist> exhibitionArtists = new ArrayList<>();
+
+    public void setStatus(ExhibitionStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/promesa/promesa/domain/exhibition/domain/Exhibition.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/domain/Exhibition.java
@@ -3,10 +3,12 @@ package com.promesa.promesa.domain.exhibition.domain;
 import com.promesa.promesa.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,6 +28,13 @@ public class Exhibition extends BaseTimeEntity {
     @NotBlank
     @Column(nullable = false)
     private String description;
+
+    @NotNull
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
 
     @NotBlank
     @Column(name = "image_key", nullable = false)

--- a/src/main/java/com/promesa/promesa/domain/exhibition/domain/ExhibitionStatus.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/domain/ExhibitionStatus.java
@@ -1,5 +1,8 @@
 package com.promesa.promesa.domain.exhibition.domain;
 
 public enum ExhibitionStatus {
-    ONGOING, ENDED
+    ONGOING,
+    UPCOMING,
+    PERMANENT,
+    PAST
 }

--- a/src/main/java/com/promesa/promesa/domain/exhibition/dto/response/ExhibitionResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/dto/response/ExhibitionResponse.java
@@ -1,35 +1,22 @@
 package com.promesa.promesa.domain.exhibition.dto.response;
 
-import com.promesa.promesa.common.application.S3Service;
-import com.promesa.promesa.domain.exhibition.domain.Exhibition;
-import com.promesa.promesa.domain.exhibition.domain.ExhibitionStatus;
+import com.promesa.promesa.domain.home.dto.response.ItemPreviewResponse;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
-public record ExhibitionResponse(
-        Long id,
-        ExhibitionStatus status,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        String title,
-        String description,
-        String imageKey,
-        String imageUrl
-) {
-    public static ExhibitionResponse of(Exhibition exhibition, String imageUrl) {
-        final S3Service s3Service;
-        return new ExhibitionResponse(
-                exhibition.getId(),
-                exhibition.getStatus(),
-                exhibition.getCreatedAt(),
-                exhibition.getUpdatedAt(),
-                exhibition.getTitle(),
-                exhibition.getDescription(),
-                exhibition.getImageKey(),
-                imageUrl
-        );
+@Getter
+public class ExhibitionResponse {
+    ExhibitionSummary summary;
+    List<ItemPreviewResponse> itemPreviews;
+
+    private ExhibitionResponse(ExhibitionSummary summary, List<ItemPreviewResponse> itemPreviews) {
+        this.summary = summary;
+        this.itemPreviews = itemPreviews;
+    }
+
+    public static ExhibitionResponse of(ExhibitionSummary summary, List<ItemPreviewResponse> itemPreviews) {
+        return new ExhibitionResponse(summary, itemPreviews);
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/exhibition/dto/response/ExhibitionSummary.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/dto/response/ExhibitionSummary.java
@@ -1,0 +1,37 @@
+package com.promesa.promesa.domain.exhibition.dto.response;
+
+import com.promesa.promesa.common.application.S3Service;
+import com.promesa.promesa.domain.exhibition.domain.Exhibition;
+import com.promesa.promesa.domain.exhibition.domain.ExhibitionStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ExhibitionSummary(
+        Long id,
+        ExhibitionStatus status,
+        String title,
+        String description,
+        LocalDate startDate,
+        LocalDate endDate,
+        String imageKey,
+        String imageUrl,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ExhibitionSummary of(Exhibition exhibition, String imageUrl) {
+        final S3Service s3Service;
+        return new ExhibitionSummary(
+                exhibition.getId(),
+                exhibition.getStatus(),
+                exhibition.getTitle(),
+                exhibition.getDescription(),
+                exhibition.getStartDate(),
+                exhibition.getEndDate(),
+                exhibition.getImageKey(),
+                imageUrl,
+                exhibition.getCreatedAt(),
+                exhibition.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/exhibition/query/ExhibitionQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/query/ExhibitionQueryRepository.java
@@ -26,4 +26,12 @@ public class ExhibitionQueryRepository {
                 .where(artist.id.eq(artistId))
                 .fetch();
     }
+
+    public List<Exhibition> findByStatusOrderByStartDateDesc(ExhibitionStatus status) {
+        return queryFactory
+                .selectFrom(exhibition)
+                .where(status != null ? exhibition.status.eq(status) : null)
+                .orderBy(exhibition.startDate.desc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/promesa/promesa/domain/exhibition/query/ExhibitionQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/exhibition/query/ExhibitionQueryRepository.java
@@ -1,6 +1,7 @@
 package com.promesa.promesa.domain.exhibition.query;
 
 import com.promesa.promesa.domain.exhibition.domain.Exhibition;
+import com.promesa.promesa.domain.exhibition.domain.ExhibitionStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -469,11 +469,11 @@ values
     (100, 2, 100)
 ;
 
-insert into exhibition (exhibition_id, created_at, updated_at, description, title, image_key, exhibition_status)
+insert into exhibition (exhibition_id, created_at, updated_at, description, title, image_key, exhibition_status, start_date, end_date)
 values
-    (1, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '따뜻한 봄 작품들', '봄 기획전', 'exhibition/1/thumnail/spring.jpg', 'ENDED'),
-    (2, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '무더운 여름 작품들', '여름 기획전', 'exhibition/2/thumnail/summer.jpg', 'ONGOING'),
-    (3, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '상큼한 토마토가 좋아', '토마토 기획전', 'exhibition/3/thumnail/tomato.jpg', 'ONGOING')
+    (1, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '따뜻한 봄 작품들', '봄 기획전', 'exhibition/1/thumnail/spring.jpg', 'PAST', '2025-03-20', '2025-04-20'),
+    (2, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '무더운 여름 작품들', '여름 기획전', 'exhibition/2/thumnail/summer.jpg', 'ONGOING', '2025-06-20', '2025-07-20'),
+    (3, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), '상큼한 토마토가 좋아', '토마토 기획전', 'exhibition/3/thumnail/tomato.jpg', 'ONGOING', '2025-07-20', null)
 ;
 
 insert into exhibition_item (exhibition_item_id, exhibition_id, item_id)


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #137 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 기획전 상태에 따라 필터링하여 기획전 목록을 반환하는 기능을 구현했습니다. 
- 각 기획전마다 작품 정보를 함께 반환합니다. 
- 기획전 시작일자를 기준으로 내림차순으로 반환합니다.
- 상설 전시회(`PERMANENT`)의 경우 종료일자`endDate`를 null로 반환합니다. 

**스케쥴러 로직**
- `UPCOMING` 시작일자 지남
    - if (종료 일자 존재O) -> `ONGOING`으로 상태 변환
    - else (종료일자 없음) -> `PERMANENT`로 상태 변환
- `ONGOING` 종료 일자 지남 -> `PAST`로 상태 변환

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
[기획전 상태별 조회 API 정리](https://www.notion.so/2361538d37f780f9b017dc0138bfde85?source=copy_link)

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
