### PR TITLE
feat: 보조 정렬 기준 추가

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/item/query/ItemQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/item/query/ItemQueryRepository.java
@@ -1,243 +1,247 @@
-package com.promesa.promesa.domain.item.query;
+    package com.promesa.promesa.domain.item.query;
 
-import com.promesa.promesa.domain.artist.domain.QArtist;
-import com.promesa.promesa.domain.home.dto.response.ItemPreviewResponse;
-import com.promesa.promesa.domain.item.domain.Item;
-import com.promesa.promesa.domain.item.domain.QItem;
-import com.promesa.promesa.domain.item.domain.QItemImage;
-import com.promesa.promesa.domain.member.domain.Member;
-import com.promesa.promesa.domain.wish.domain.TargetType;
-import com.querydsl.core.types.*;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.PathBuilder;
-import com.querydsl.jpa.impl.JPAQuery;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.stereotype.Repository;
+    import com.promesa.promesa.domain.artist.domain.QArtist;
+    import com.promesa.promesa.domain.home.dto.response.ItemPreviewResponse;
+    import com.promesa.promesa.domain.item.domain.Item;
+    import com.promesa.promesa.domain.item.domain.QItem;
+    import com.promesa.promesa.domain.item.domain.QItemImage;
+    import com.promesa.promesa.domain.member.domain.Member;
+    import com.promesa.promesa.domain.wish.domain.TargetType;
+    import com.querydsl.core.types.*;
+    import com.querydsl.core.types.dsl.BooleanExpression;
+    import com.querydsl.core.types.dsl.Expressions;
+    import com.querydsl.core.types.dsl.PathBuilder;
+    import com.querydsl.jpa.impl.JPAQuery;
+    import org.springframework.data.domain.Page;
+    import org.springframework.data.domain.Pageable;
+    import com.querydsl.jpa.impl.JPAQueryFactory;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.data.domain.Sort;
+    import org.springframework.data.support.PageableExecutionUtils;
+    import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
+    import java.util.ArrayList;
+    import java.util.List;
 
-import static com.promesa.promesa.domain.artist.domain.QArtist.artist;
-import static com.promesa.promesa.domain.exhibition.domain.QExhibitionItem.exhibitionItem;
-import static com.promesa.promesa.domain.item.domain.QItem.item;
-import static com.promesa.promesa.domain.item.domain.QItemImage.itemImage;
-import static com.promesa.promesa.domain.itemCategory.domain.QItemCategory.itemCategory;
-import static com.promesa.promesa.domain.wish.domain.QWish.wish;
+    import static com.promesa.promesa.domain.artist.domain.QArtist.artist;
+    import static com.promesa.promesa.domain.exhibition.domain.QExhibitionItem.exhibitionItem;
+    import static com.promesa.promesa.domain.item.domain.QItem.item;
+    import static com.promesa.promesa.domain.item.domain.QItemImage.itemImage;
+    import static com.promesa.promesa.domain.itemCategory.domain.QItemCategory.itemCategory;
+    import static com.promesa.promesa.domain.wish.domain.QWish.wish;
 
-@Repository
-@RequiredArgsConstructor
-public class ItemQueryRepository {
-    private final JPAQueryFactory queryFactory;
+    @Repository
+    @RequiredArgsConstructor
+    public class ItemQueryRepository {
+        private final JPAQueryFactory queryFactory;
 
-    /**
-     * 기획전 상품을 위시리스트 여부와 함께 반환
-     * @param member
-     * @return
-     */
-    public List<ItemPreviewResponse> findExhibitionItem(Member member, Long exhibitionId) {
-        Expression<Boolean> isWished = isWishedExpression(member);
+        /**
+         * 기획전 상품을 위시리스트 여부와 함께 반환
+         * @param member
+         * @return
+         */
+        public List<ItemPreviewResponse> findExhibitionItem(Member member, Long exhibitionId) {
+            Expression<Boolean> isWished = isWishedExpression(member);
 
-        JPAQuery<ItemPreviewResponse> query = queryFactory
-                .select(Projections.fields(ItemPreviewResponse.class,
-                        item.id.as("itemId"),
-                        item.saleStatus.as("saleStatus"),
-                        item.name.as("itemName"),
-                        item.price,
-                        itemImage.imageKey.as("imageUrl"),
-                        artist.name.as("artistName"),
-                        ExpressionUtils.as(isWished, "isWished"),
-                        item.wishCount.as("wishCount")
-                ))
-                .from(exhibitionItem)
-                .join(exhibitionItem.item, item)
-                .join(item.artist, artist)
-                .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
-                .where(exhibitionItem.exhibition.id.eq(exhibitionId));
+            JPAQuery<ItemPreviewResponse> query = queryFactory
+                    .select(Projections.fields(ItemPreviewResponse.class,
+                            item.id.as("itemId"),
+                            item.saleStatus.as("saleStatus"),
+                            item.name.as("itemName"),
+                            item.price,
+                            itemImage.imageKey.as("imageUrl"),
+                            artist.name.as("artistName"),
+                            ExpressionUtils.as(isWished, "isWished"),
+                            item.wishCount.as("wishCount")
+                    ))
+                    .from(exhibitionItem)
+                    .join(exhibitionItem.item, item)
+                    .join(item.artist, artist)
+                    .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
+                    .where(exhibitionItem.exhibition.id.eq(exhibitionId));
 
-        if (member != null) {
-            query.leftJoin(wish).on(
-                    wish.member.id.eq(member.getId())
-                            .and(wish.targetType.eq(TargetType.ITEM))
-                            .and(wish.targetId.eq(item.id))
-            );
+            if (member != null) {
+                query.leftJoin(wish).on(
+                        wish.member.id.eq(member.getId())
+                                .and(wish.targetType.eq(TargetType.ITEM))
+                                .and(wish.targetId.eq(item.id))
+                );
+            }
+            return query.fetch();
         }
-        return query.fetch();
-    }
 
-    /**
-     * 카테고리 작품 조회
-     * @param member
-     * @param categoryId
-     * @return
-     */
-    public Page<ItemPreviewResponse> findCategoryItem(Member member, Long categoryId, Pageable pageable) {
-        Expression<Boolean> isWished = isWishedExpression(member);
-        BooleanExpression categoryCondition = (categoryId != 0) ? itemCategory.category.id.eq(categoryId) : null;
+        /**
+         * 카테고리 작품 조회
+         * @param member
+         * @param categoryId
+         * @return
+         */
+        public Page<ItemPreviewResponse> findCategoryItem(Member member, Long categoryId, Pageable pageable) {
+            Expression<Boolean> isWished = isWishedExpression(member);
+            BooleanExpression categoryCondition = (categoryId != 0) ? itemCategory.category.id.eq(categoryId) : null;
 
-        JPAQuery<ItemPreviewResponse> query = queryFactory
-                .select(Projections.fields(ItemPreviewResponse.class,
-                        item.id.as("itemId"),
-                        item.saleStatus.as("saleStatus"),
-                        item.name.as("itemName"),
-                        item.price,
-                        itemImage.imageKey.as("imageUrl"),
-                        artist.name.as("artistName"),
-                        ExpressionUtils.as(isWished, "isWished"),
-                        item.wishCount.as("wishCount")
-                ));
-        if (categoryId != 0) {
-            query.from(itemCategory)
+            JPAQuery<ItemPreviewResponse> query = queryFactory
+                    .select(Projections.fields(ItemPreviewResponse.class,
+                            item.id.as("itemId"),
+                            item.saleStatus.as("saleStatus"),
+                            item.name.as("itemName"),
+                            item.price,
+                            itemImage.imageKey.as("imageUrl"),
+                            artist.name.as("artistName"),
+                            ExpressionUtils.as(isWished, "isWished"),
+                            item.wishCount.as("wishCount")
+                    ));
+            if (categoryId != 0) {
+                query.from(itemCategory)
+                        .join(itemCategory.item, item)
+                        .join(item.artist, artist)
+                        .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
+                        .where(itemCategory.category.id.eq(categoryId));
+            } else {
+                query.from(item)
+                        .join(item.artist, artist)
+                        .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue());
+            }
+
+            if (!pageable.getSort().isEmpty()) {
+                List<OrderSpecifier<?>> specifiers = new ArrayList<>(List.of(createOrderSpecifiers(pageable.getSort())));
+                specifiers.add(item.id.desc());  // 보조 정렬 기준
+                query.orderBy(specifiers.toArray(new OrderSpecifier[0]));
+            }
+
+            if (member != null) {
+                query.leftJoin(wish).on(
+                        wish.member.id.eq(member.getId())
+                                .and(wish.targetType.eq(TargetType.ITEM))
+                                .and(wish.targetId.eq(item.id))
+                );
+            }
+
+            query.offset(pageable.getOffset())
+                    .limit(pageable.getPageSize());
+            List<ItemPreviewResponse> content = query.fetch();
+
+            JPAQuery<Long> countQuery;
+
+            if (categoryId != 0) {
+                countQuery = queryFactory
+                        .select(item.count())
+                        .from(itemCategory)
+                        .join(itemCategory.item, item)
+                        .where(itemCategory.category.id.eq(categoryId));
+            } else {
+                countQuery = queryFactory
+                        .select(item.count())
+                        .from(item);
+            }
+
+            return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        }
+
+        /**
+         * 작가의 카테고리별 작품 조회
+         * @param member
+         * @param artistId
+         * @param categoryId
+         * @return
+         */
+        public List<ItemPreviewResponse> findItemsByArtistAndCategory(
+                Member member,
+                Long artistId,
+                Long categoryId,
+                Pageable pageable
+        ) {
+            Expression<Boolean> isWished = isWishedExpression(member);
+            BooleanExpression categoryCondition = (categoryId != 0) ? itemCategory.category.id.eq(categoryId) : null;
+            BooleanExpression artistCondition = artist.id.eq(artistId);
+
+            JPAQuery<ItemPreviewResponse> query = queryFactory
+                    .select(Projections.fields(ItemPreviewResponse.class,
+                            item.id.as("itemId"),
+                            item.saleStatus.as("saleStatus"),
+                            item.name.as("itemName"),
+                            item.price,
+                            itemImage.imageKey.as("imageUrl"),
+                            artist.name.as("artistName"),
+                            ExpressionUtils.as(isWished, "isWished"),
+                            item.wishCount.as("wishCount")
+                    ))
+                    .from(itemCategory)
                     .join(itemCategory.item, item)
                     .join(item.artist, artist)
                     .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
-                    .where(itemCategory.category.id.eq(categoryId));
-        } else {
-            query.from(item)
+                    .where(artistCondition, categoryCondition);
+
+            if (!pageable.getSort().isEmpty()) {
+                List<OrderSpecifier<?>> specifiers = new ArrayList<>(List.of(createOrderSpecifiers(pageable.getSort())));
+                specifiers.add(item.id.desc());  // 보조 정렬 기준
+                query.orderBy(specifiers.toArray(new OrderSpecifier[0]));
+            }
+
+            if (member != null) {
+                query.leftJoin(wish).on(
+                        wish.member.id.eq(member.getId())
+                                .and(wish.targetType.eq(TargetType.ITEM))
+                                .and(wish.targetId.eq(item.id))
+                );
+            }
+
+            return query.fetch();
+        }
+
+        private OrderSpecifier<?>[] createOrderSpecifiers(Sort sort) {
+            List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+
+            for (Sort.Order order : sort) {
+                String property = order.getProperty();  // 정렬 조건
+                Order dicrection = order.isAscending() ? Order.ASC : Order.DESC;    // 오름차순, 내림차순
+                PathBuilder path = new PathBuilder(Item.class, "item");
+
+                specifiers.add(new OrderSpecifier(dicrection, path.get(property))); // 복합 정렬
+            }
+
+            return specifiers.toArray(new OrderSpecifier[0]);   // List를 Array로 변환
+        }
+
+        /**
+         * member가 null이면 false 아니면 wish.id 존재 여부 반환
+         */
+        private Expression<Boolean> isWishedExpression(Member member) {
+            if (member == null) {
+                return Expressions.asBoolean(false);
+            }
+
+            return wish.id.isNotNull();
+        }
+
+        /**
+         * 작품 이름 검색
+         * @param keyword
+         * @param member
+         * @return
+         */
+        public List<ItemPreviewResponse> searchByItemName(String keyword, Member member) {
+            Expression<Boolean> isWished = isWishedExpression(member);
+
+            return queryFactory
+                    .select(Projections.fields(ItemPreviewResponse.class,
+                            item.id.as("itemId"),
+                            item.saleStatus.as("saleStatus"),
+                            item.name.as("itemName"),
+                            item.price,
+                            itemImage.imageKey.as("imageUrl"),
+                            artist.name.as("artistName"),
+                            ExpressionUtils.as(isWished, "isWished"),
+                            item.wishCount.as("wishCount")
+                    ))
+                    .from(item)
                     .join(item.artist, artist)
-                    .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue());
+                    .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
+                    .where(
+                            Expressions.stringTemplate("REPLACE({0}, ' ', '')", item.name)
+                                    .containsIgnoreCase(keyword)
+                    )
+
+                    .fetch();
         }
-
-        if (pageable.getSort() != null) {
-            query.orderBy(createOrderSpecifiers(pageable.getSort()));
-        }
-
-        if (member != null) {
-            query.leftJoin(wish).on(
-                    wish.member.id.eq(member.getId())
-                            .and(wish.targetType.eq(TargetType.ITEM))
-                            .and(wish.targetId.eq(item.id))
-            );
-        }
-
-        query.offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-        List<ItemPreviewResponse> content = query.fetch();
-
-        JPAQuery<Long> countQuery;
-
-        if (categoryId != 0) {
-            countQuery = queryFactory
-                    .select(item.count())
-                    .from(itemCategory)
-                    .join(itemCategory.item, item)
-                    .where(itemCategory.category.id.eq(categoryId));
-        } else {
-            countQuery = queryFactory
-                    .select(item.count())
-                    .from(item);
-        }
-
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
-
-    /**
-     * 작가의 카테고리별 작품 조회
-     * @param member
-     * @param artistId
-     * @param categoryId
-     * @return
-     */
-    public List<ItemPreviewResponse> findItemsByArtistAndCategory(
-            Member member,
-            Long artistId,
-            Long categoryId,
-            Pageable pageable
-    ) {
-        Expression<Boolean> isWished = isWishedExpression(member);
-        BooleanExpression categoryCondition = (categoryId != 0) ? itemCategory.category.id.eq(categoryId) : null;
-        BooleanExpression artistCondition = artist.id.eq(artistId);
-
-        JPAQuery<ItemPreviewResponse> query = queryFactory
-                .select(Projections.fields(ItemPreviewResponse.class,
-                        item.id.as("itemId"),
-                        item.saleStatus.as("saleStatus"),
-                        item.name.as("itemName"),
-                        item.price,
-                        itemImage.imageKey.as("imageUrl"),
-                        artist.name.as("artistName"),
-                        ExpressionUtils.as(isWished, "isWished"),
-                        item.wishCount.as("wishCount")
-                ))
-                .from(itemCategory)
-                .join(itemCategory.item, item)
-                .join(item.artist, artist)
-                .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
-                .where(artistCondition, categoryCondition);
-
-        if (pageable.getSort() != null) {
-            query.orderBy(createOrderSpecifiers(pageable.getSort()));
-        }
-
-        if (member != null) {
-            query.leftJoin(wish).on(
-                    wish.member.id.eq(member.getId())
-                            .and(wish.targetType.eq(TargetType.ITEM))
-                            .and(wish.targetId.eq(item.id))
-            );
-        }
-
-        return query.fetch();
-    }
-
-    private OrderSpecifier<?>[] createOrderSpecifiers(Sort sort) {
-        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
-
-        for (Sort.Order order : sort) {
-            String property = order.getProperty();  // 정렬 조건
-            Order dicrection = order.isAscending() ? Order.ASC : Order.DESC;    // 오름차순, 내림차순
-            PathBuilder path = new PathBuilder(Item.class, "item");
-
-            specifiers.add(new OrderSpecifier(dicrection, path.get(property))); // 복합 정렬
-        }
-
-        return specifiers.toArray(new OrderSpecifier[0]);   // List를 Array로 변환
-    }
-
-    /**
-     * member가 null이면 false 아니면 wish.id 존재 여부 반환
-     */
-    private Expression<Boolean> isWishedExpression(Member member) {
-        if (member == null) {
-            return Expressions.asBoolean(false);
-        }
-
-        return wish.id.isNotNull();
-    }
-
-    /**
-     * 작품 이름 검색
-     * @param keyword
-     * @param member
-     * @return
-     */
-    public List<ItemPreviewResponse> searchByItemName(String keyword, Member member) {
-        Expression<Boolean> isWished = isWishedExpression(member);
-
-        return queryFactory
-                .select(Projections.fields(ItemPreviewResponse.class,
-                        item.id.as("itemId"),
-                        item.saleStatus.as("saleStatus"),
-                        item.name.as("itemName"),
-                        item.price,
-                        itemImage.imageKey.as("imageUrl"),
-                        artist.name.as("artistName"),
-                        ExpressionUtils.as(isWished, "isWished"),
-                        item.wishCount.as("wishCount")
-                ))
-                .from(item)
-                .join(item.artist, artist)
-                .leftJoin(item.itemImages, itemImage).on(itemImage.isThumbnail.isTrue())
-                .where(
-                        Expressions.stringTemplate("REPLACE({0}, ' ', '')", item.name)
-                                .containsIgnoreCase(keyword)
-                )
-
-                .fetch();
-    }
-}


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #148 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 보조 정렬 기준을 추가했습니다. 
- 기존에는 wishCount,desc를 정렬 조건으로 줄 경우, wishCount가 같은 작품일 때 그 안에서 순서가 랜덤하게 정해졌습니다. 
- 따라서 조회마다 순서가 바껴서 페이지가 넘어갔음에도 작품이 중복으로 조회되는 등의 문제가 있었습니다.
- 보조 정렬 기준으로 **✨itemId 내림차순**을 주어 1차 정렬 기준에서 같은 값 내부에서도 순서를 유지하도록 했습니다. 

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
