### PR TITLE
refactor: 장바구니 관련 dto 필드 수정 및 버그 해결 

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/cartItem/application/CartItemService.java
+++ b/src/main/java/com/promesa/promesa/domain/cartItem/application/CartItemService.java
@@ -10,11 +10,14 @@ import com.promesa.promesa.domain.cartItem.exception.CartItemNotFoundException;
 import com.promesa.promesa.domain.item.dao.ItemRepository;
 import com.promesa.promesa.domain.item.domain.Item;
 import com.promesa.promesa.domain.item.exception.ItemNotFoundException;
+import com.promesa.promesa.domain.member.dao.MemberRepository;
 import com.promesa.promesa.domain.member.domain.Member;
+import com.promesa.promesa.domain.member.exception.MemberNotFoundException;
 import com.promesa.promesa.domain.order.exception.InvalidOrderQuantityException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,25 +27,29 @@ public class CartItemService {
 
     private final CartItemRepository cartItemRepository;
     private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
     private final S3Service s3Service;
 
     @Value("${aws.s3.bucket}")
     private String bucketName;
 
+    @Transactional
     public CartItemResponse addToCart(Member member, CartItemAddRequest request) {
+        Member persistentMember = getPersistentMember(member);
+
         if (request.quantity() <= 0) throw InvalidOrderQuantityException.EXCEPTION;
 
         Item item = itemRepository.findById(request.itemId())
                 .orElseThrow(() -> ItemNotFoundException.EXCEPTION);
 
-        CartItem cartItem = cartItemRepository.findByMemberAndItem(member, item)
+        CartItem cartItem = cartItemRepository.findByMemberAndItem(persistentMember, item)
                 .orElse(null);
 
         if (cartItem != null) {
             cartItem.setQuantity(cartItem.getQuantity() + request.quantity());
         } else {
             cartItem = cartItemRepository.save(CartItem.builder()
-                    .member(member)
+                    .member(persistentMember)
                     .item(item)
                     .quantity(request.quantity())
                     .build());
@@ -50,13 +57,16 @@ public class CartItemService {
         return CartItemResponse.of(cartItem, s3Service, bucketName);
     }
 
+    @Transactional
     public CartItemResponse updateCartItem(Member member, CartItemUpdateRequest request) {
+        Member persistentMember = getPersistentMember(member);
+
         if (request.quantity() <= 0) throw InvalidOrderQuantityException.EXCEPTION;
 
         Item item = itemRepository.findById(request.itemId())
                 .orElseThrow(() -> ItemNotFoundException.EXCEPTION);
 
-        CartItem cartItem = cartItemRepository.findByMemberAndItem(member, item)
+        CartItem cartItem = cartItemRepository.findByMemberAndItem(persistentMember, item)
                 .orElseThrow(()-> CartItemNotFoundException.EXCEPTION);
 
         cartItem.setQuantity(request.quantity());
@@ -64,11 +74,14 @@ public class CartItemService {
         return CartItemResponse.of(cartItem, s3Service, bucketName);
     }
 
+    @Transactional
     public CartItemResponse deleteCartItem(Member member, Long itemId) {
+        Member persistentMember = getPersistentMember(member);
+
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> ItemNotFoundException.EXCEPTION);
 
-        CartItem cartItem = cartItemRepository.findByMemberAndItem(member, item)
+        CartItem cartItem = cartItemRepository.findByMemberAndItem(persistentMember, item)
                 .orElseThrow(()-> CartItemNotFoundException.EXCEPTION);
 
         cartItemRepository.delete(cartItem);
@@ -77,11 +90,18 @@ public class CartItemService {
     }
 
     public List<CartItemResponse> getCartItems(Member member) {
-        List<CartItem> items = cartItemRepository.findByMember(member);
+        Member persistentMember = getPersistentMember(member);
+
+        List<CartItem> items = cartItemRepository.findByMember(persistentMember);
 
         return items.stream()
                 .map(ci -> CartItemResponse.of(ci, s3Service, bucketName))
                 .toList();
+    }
+
+    private Member getPersistentMember(Member member) {
+        return memberRepository.findById(member.getId())
+                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
     }
 
 }

--- a/src/main/java/com/promesa/promesa/domain/cartItem/dto/CartItemResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/cartItem/dto/CartItemResponse.java
@@ -4,6 +4,7 @@ import com.promesa.promesa.common.application.S3Service;
 import com.promesa.promesa.domain.cartItem.domain.CartItem;
 import com.promesa.promesa.domain.item.domain.Item;
 import com.promesa.promesa.domain.item.domain.ItemImage;
+import com.promesa.promesa.domain.item.domain.SaleStatus;
 
 public record CartItemResponse(
         Long cartItemId,
@@ -12,7 +13,9 @@ public record CartItemResponse(
         String name,
         String artistName,
         int price,
-        String thumbnailUrl
+        String thumbnailUrl,
+        int stock,
+        SaleStatus saleStatus
 ) {
     public static CartItemResponse of(CartItem cartItem, S3Service s3Service, String bucketName) {
         Item item = cartItem.getItem();
@@ -30,7 +33,9 @@ public record CartItemResponse(
                 item.getName(),
                 item.getArtist().getName(),
                 item.getPrice(),
-                thumbnailUrl
+                thumbnailUrl,
+                item.getStock(),
+                item.getSaleStatus()
         );
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/item/dto/ItemSale.java
+++ b/src/main/java/com/promesa/promesa/domain/item/dto/ItemSale.java
@@ -1,10 +1,11 @@
 package com.promesa.promesa.domain.item.dto;
 
 import com.promesa.promesa.domain.item.domain.Item;
+import com.promesa.promesa.domain.item.domain.SaleStatus;
 
 public record ItemSale(
         int stock,
-        boolean soldOut,
+        SaleStatus saleStatus,
         int price,
         boolean freeShipping,
         String shippingPolicy
@@ -12,7 +13,7 @@ public record ItemSale(
     public static ItemSale from(Item item) {
         return new ItemSale(
                 item.getStock(),
-                item.getStock() == 0,
+                item.getSaleStatus(),
                 item.getPrice(),
                 item.getPrice() >= 70000,
                 "제주/도서산간 3,000원 추가"


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #159 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- CartItemResponse에 stock, saleStatus 추가
- ItemSale에서 boolean soldOut -> Enum(SaleStatus) saleStatus로 수정

### 버그 해결
- 문제
  - 조회 -> 수정 -> 조회 해보면 수정 사항이 반영이 안됐었음.(success가 떴는데도)
- 원인
  - member가 jpa가 관리하는 영속 객체가 아니어서
- 해결
  - member를 memberRepository로 한번 받아온 후 사용하도록 수정 
  - 관련 메서드 만듦(getPersistentMember)
  - @Transactional 추가
---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
- 저 버그가 스웨거에서만 생기는 것 같긴 한데....아니라면 나중에 전반적으로 바꿔야할수도... 
  - 근데 스웨거만 생기는 것 같긴 합니다(트랜잭션이 끝나기 전에 바로 다음 요청이 도착해서)
- 혹시 다른 api 테스트하다가 저런 문제 있으면 이렇게 해결하면 될 것 같아요..!

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
