### PR TITLE
feat: 사용자 리뷰 조회 기능 추가

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/order/dao/OrderRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dao/OrderRepository.java
@@ -2,6 +2,7 @@ package com.promesa.promesa.domain.order.dao;
 
 import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.domain.order.domain.Order;
+import com.promesa.promesa.domain.order.domain.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,5 +11,7 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByMember(Member member);
     Optional<Order> findByIdAndMember(Long id, Member member);
+
+    List<Order> findByOrderStatus(OrderStatus orderStatus);
 }
 

--- a/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 public class OrderItemSummary {
+    private Long orderId;
     private Long orderItemId;
     private String itemName;
     private String artistName;

--- a/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
@@ -21,4 +21,8 @@ public class OrderItemSummary {
     private LocalDateTime orderDate;
     private OrderStatus orderStatus;
     private int quantity;
+
+    public void setItemThumbnail(String itemThumbnail) {
+        this.itemThumbnail = itemThumbnail;
+    }
 }

--- a/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 public class OrderItemSummary {
     private Long orderId;
     private Long orderItemId;
+    private Long itemId;
     private String itemName;
     private String artistName;
     private String itemThumbnail;

--- a/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dto/response/OrderItemSummary.java
@@ -1,0 +1,22 @@
+package com.promesa.promesa.domain.order.dto.response;
+
+import com.promesa.promesa.domain.order.domain.OrderItem;
+import com.promesa.promesa.domain.order.domain.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class OrderItemSummary {
+    private Long orderItemId;
+    private String itemName;
+    private String artistName;
+    private String itemThumbnail;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private int quantity;
+}

--- a/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
+++ b/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
@@ -4,6 +4,7 @@ import com.promesa.promesa.common.dto.s3.PresignedUrlRequest;
 import com.promesa.promesa.common.dto.s3.PresignedUrlResponse;
 import com.promesa.promesa.domain.member.dao.MemberRepository;
 import com.promesa.promesa.domain.member.domain.Member;
+import com.promesa.promesa.domain.order.dto.response.OrderItemSummary;
 import com.promesa.promesa.domain.review.application.ReviewImageService;
 import com.promesa.promesa.domain.review.application.ReviewService;
 import com.promesa.promesa.domain.review.dto.request.AddReviewRequest;
@@ -95,15 +96,26 @@ public class ReviewController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("members/me/reviews")
+    @GetMapping("/members/me/reviews")
     @Operation(summary = "작성한 리뷰 조회")
-    public ResponseEntity<Page<ReviewResponse>> getMyReviews(
-            @ParameterObject Pageable pageable,
+    public ResponseEntity<List<ReviewResponse>> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails user
     )
     {
         Member member = (user != null) ? user.getMember() : null;
-        Page<ReviewResponse> response = reviewService.getMyReviews(member, pageable);
+        List<ReviewResponse> response = reviewService.getMyReviews(member);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @GetMapping("/members/me/reviews/eligible")
+    @Operation(summary = "작성 가능한 리뷰 조회")
+    public ResponseEntity<List<OrderItemSummary>> getMyEligibleReviews(
+            @AuthenticationPrincipal CustomUserDetails user
+    )
+    {
+        Member member = (user != null) ? user.getMember() : null;
+        List<OrderItemSummary> response = reviewService.getMyEligibleReviews(member);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
+++ b/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
@@ -9,6 +9,7 @@ import com.promesa.promesa.domain.review.application.ReviewImageService;
 import com.promesa.promesa.domain.review.application.ReviewService;
 import com.promesa.promesa.domain.review.dto.request.AddReviewRequest;
 import com.promesa.promesa.domain.review.dto.request.UpdateReviewRequest;
+import com.promesa.promesa.domain.review.dto.response.ReviewDetailResponse;
 import com.promesa.promesa.domain.review.dto.response.ReviewResponse;
 import com.promesa.promesa.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -98,12 +99,12 @@ public class ReviewController {
 
     @GetMapping("/members/me/reviews")
     @Operation(summary = "작성한 리뷰 조회")
-    public ResponseEntity<List<ReviewResponse>> getMyReviews(
+    public ResponseEntity<List<ReviewDetailResponse>> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails user
     )
     {
         Member member = (user != null) ? user.getMember() : null;
-        List<ReviewResponse> response = reviewService.getMyReviews(member);
+        List<ReviewDetailResponse> response = reviewService.getMyReviews(member);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
+++ b/src/main/java/com/promesa/promesa/domain/review/api/ReviewController.java
@@ -94,4 +94,16 @@ public class ReviewController {
         Page<ReviewResponse> responses = reviewService.getReviews(itemId, pageable);
         return ResponseEntity.ok(responses);
     }
+
+    @GetMapping("members/me/reviews")
+    @Operation(summary = "작성한 리뷰 조회")
+    public ResponseEntity<Page<ReviewResponse>> getMyReviews(
+            @ParameterObject Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails user
+    )
+    {
+        Member member = (user != null) ? user.getMember() : null;
+        Page<ReviewResponse> response = reviewService.getMyReviews(member, pageable);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewDetailResponse.java
@@ -1,0 +1,19 @@
+package com.promesa.promesa.domain.review.dto.response;
+
+import com.promesa.promesa.domain.order.dto.response.OrderItemSummary;
+import lombok.Getter;
+
+@Getter
+public class ReviewDetailResponse {
+    OrderItemSummary orderItemSummary;
+    ReviewResponse reviewResponse;
+
+    public ReviewDetailResponse(OrderItemSummary orderItemSummary, ReviewResponse reviewResponse) {
+        this.orderItemSummary = orderItemSummary;
+        this.reviewResponse = reviewResponse;
+    }
+
+    public static ReviewDetailResponse of(OrderItemSummary orderItemSummary, ReviewResponse reviewResponse) {
+        return new ReviewDetailResponse(orderItemSummary, reviewResponse);
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewQueryDto.java
+++ b/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewQueryDto.java
@@ -13,6 +13,7 @@ public class ReviewQueryDto {
     private Long reviewId;
     private String content;
     private Long itemId;
+    private Long orderItemId;
     private Long reviewerId;
     private String reviewerName;
     private int rating;

--- a/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/promesa/promesa/domain/review/dto/response/ReviewResponse.java
@@ -1,6 +1,7 @@
 package com.promesa.promesa.domain.review.dto.response;
 
 import com.promesa.promesa.domain.review.domain.Review;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,14 +10,16 @@ import java.util.List;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class ReviewResponse {
     private final Long reviewId;
     private final String content;
     private final Long itemId;
+    private final Long orderItemId;
     private final Long reviewerId;
     private final String reviewerName;
     private final int rating;
-    private final List<String> reviewImages;
+    private List<String> reviewImages;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
@@ -25,6 +28,7 @@ public class ReviewResponse {
                 .reviewId(review.getId())
                 .content(review.getContent())
                 .itemId(review.getItem().getId())
+                .orderItemId(review.getOrderItem().getId())
                 .reviewerId(review.getMember().getId())
                 .reviewerName(review.getMember().getName())
                 .rating(review.getRating())
@@ -39,6 +43,7 @@ public class ReviewResponse {
                 .reviewId(dto.getReviewId())
                 .content(dto.getContent())
                 .itemId(dto.getItemId())
+                .orderItemId(dto.getOrderItemId())
                 .reviewerId(dto.getReviewerId())
                 .reviewerName(dto.getReviewerName())
                 .rating(dto.getRating())
@@ -46,5 +51,9 @@ public class ReviewResponse {
                 .createdAt(dto.getCreatedAt())
                 .updatedAt(dto.getUpdatedAt())
                 .build();
+    }
+
+    public void setReviewImages(List<String> imageUrls) {
+        reviewImages = imageUrls;
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
@@ -126,6 +126,7 @@ public class ReviewQueryRepository {
                 .select(Projections.fields(OrderItemSummary.class,
                         orderItem.order.id.as("orderId"),
                         orderItem.id.as("orderItemId"),
+                        orderItem.item.id.as("itemId"),
                         orderItem.item.name.as("itemName"),
                         orderItem.item.artist.name.as("artistName"),
                         orderItem.order.orderDate.as("orderDate"),

--- a/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
@@ -124,6 +124,7 @@ public class ReviewQueryRepository {
     public List<OrderItemSummary> getMyEligibleReviews(Long memberId) {
         List<OrderItemSummary> results = queryFactory
                 .select(Projections.fields(OrderItemSummary.class,
+                        orderItem.order.id.as("orderId"),
                         orderItem.id.as("orderItemId"),
                         orderItem.item.name.as("itemName"),
                         orderItem.item.artist.name.as("artistName"),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -582,14 +582,13 @@ values
     (1, 5, 1, current_timestamp, current_timestamp),
     (1, 4, 1, current_timestamp, current_timestamp);
 
-insert into "order" (member_id, order_status, order_date,
-    bank_name, depositor_name, deposit_deadline,
-    total_amount, total_quantity, created_at, updated_at
-) values (
+insert into "order" (member_id, order_status, order_date, bank_name, account_number, depositor_name, deposit_deadline, total_amount, total_quantity, created_at, updated_at)
+values (
              1,
              'PAID',
              CURRENT_TIMESTAMP,
-             '국민은행 123456-78-901234',
+             '국민은행',
+             '123456-78-901234',
              '홍길동',
              CURRENT_TIMESTAMP + 1,
              120000,
@@ -612,7 +611,7 @@ insert into "order" (member_id, order_status, order_date,
          ),
          (
              2,
-             'WAITING_FOR_PAYMENT',
+             'DELIVERED',
              CURRENT_TIMESTAMP,
              '국민은행',
              '123456-78-901234',
@@ -652,14 +651,23 @@ values
 insert into delivery (
     order_id, courier_name, receiver_name, receiver_phone, zip_code, address, address_detail,
     delivery_status, delivery_expected_date, delivery_start_date, delivery_completed_date,delivery_fee
-) values (
-             1, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
-             'SHIPPED', '2025-07-25', '2025-07-22', null,3000
-         );
+)
+values (
+             2, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
+             'DELIVERED', CURRENT_TIMESTAMP + 3, CURRENT_TIMESTAMP + 1, CURRENT_TIMESTAMP + 2,3000
+         ),
+       (
+           3, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
+           'DELIVERED', '2025-07-25', '2025-07-22', null,3000
+       ),
+       (
+           4, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
+           'DELIVERED', '2025-07-25', '2025-07-22', null,3000
+       );
 
 insert into review (review_id, order_item_id, item_id, member_id, rating, content, created_at, updated_at)
-values (1, 1, 1, 1, 1, '도자기가 다 깨져서 왔어요ㅠㅠㅠㅠㅠㅠㅠㅠㅠ',CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),
-       (2, 2, 2, 1, 5, '완전 굿굿굿굿짱짱짱짱이에욤', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+values (1, 1, 1, 2, 1, '도자기가 다 깨져서 왔어요ㅠㅠㅠㅠㅠㅠㅠㅠㅠ',CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()),
+       (2, 2, 2, 2, 5, '완전 굿굿굿굿짱짱짱짱이에욤', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
 
 insert into review_image (review_image_id, review_id, image_key, created_at, updated_at)
 values (1, 1, 'member/1/review/1/불만.jpg', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -635,60 +635,6 @@ values (
              CURRENT_TIMESTAMP,
              CURRENT_TIMESTAMP
          );
-insert into "order" (member_id, order_status, order_date, bank_name, account_number, depositor_name, deposit_deadline, total_amount, total_quantity, created_at, updated_at)
-values (
-           1,
-           'PAID',
-           CURRENT_TIMESTAMP,
-           '국민은행',
-           '123456-78-901234',
-           '홍길동',
-           CURRENT_TIMESTAMP + 1,
-           120000,
-           2,
-           CURRENT_TIMESTAMP,
-           CURRENT_TIMESTAMP
-       ),
-       (
-           2,
-           'DELIVERED',
-           CURRENT_TIMESTAMP,
-           '국민은행',
-           '123456-78-901234',
-           '홍길동',
-           CURRENT_TIMESTAMP + 1,
-           120000,
-           2,
-           CURRENT_TIMESTAMP,
-           CURRENT_TIMESTAMP
-       ),
-       (
-           2,
-           'DELIVERED',
-           CURRENT_TIMESTAMP,
-           '국민은행',
-           '123456-78-901234',
-           '홍길동',
-           CURRENT_TIMESTAMP + 1,
-           120000,
-           2,
-           CURRENT_TIMESTAMP,
-           CURRENT_TIMESTAMP
-       ),
-       (
-           2,
-           'DELIVERED',
-           CURRENT_TIMESTAMP,
-           '국민은행',
-           '123456-78-901234',
-           '홍길동',
-           CURRENT_TIMESTAMP + 1,
-           120000,
-           2,
-           CURRENT_TIMESTAMP,
-           CURRENT_TIMESTAMP
-       );
-
 
 insert into order_item (item_id, order_id, quantity, price, order_item_id)
 values
@@ -706,22 +652,13 @@ insert into delivery (
     delivery_status, delivery_expected_date, delivery_start_date, delivery_completed_date,delivery_fee
 )
 values (
+           1, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '103호',
+           'READY',  null, null, null,3000
+       ),
+       (
              2, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
              'DELIVERED', CURRENT_TIMESTAMP + 3, CURRENT_TIMESTAMP + 1, CURRENT_TIMESTAMP + 2,3000
          ),
-       (
-           3, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
-           'DELIVERED', '2025-07-25', '2025-07-22', null,3000
-       ),
-       (
-           4, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
-           'DELIVERED', '2025-07-25', '2025-07-22', null,3000
-       );
-)
-values (
-           2, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
-           'DELIVERED', CURRENT_TIMESTAMP + 3, CURRENT_TIMESTAMP + 1, CURRENT_TIMESTAMP + 2,3000
-       ),
        (
            3, 'cj대한통운', '프로메사', '010-1234-5678', '12345', '서울특별시 종로구 세종대로', '101호',
            'DELIVERED', '2025-07-25', '2025-07-22', null,3000


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #140 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
#### ✨작성한 리뷰 조회
- 사용자가 작성한 리뷰를 최신순으로 정렬하여 반환

#### ✨작성 가능한 리뷰 조회
**필터링**
1. 로그인한 회원의 주문 내역 정보 조회
2. 해당 주문이 배송 완료된 상태여야 함
3. 하나의 주문 당 여러 개의 작품 존재, 작품 각각에 대해 리뷰를 작성 가능
4. 작성한 리뷰가 존재하지 않는 작품만 가져옴(작품 구매 당 리뷰 한 번만 가능)
5. 동일한 작품을 여러 번 구매 시 리뷰도 구매 횟수만큼 작성 가능

**정렬**
1. 주문 최신 순
2. 같은 주문일 경우 `order_item_id` 오름차순
---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
