### PR TITLE
feat: 회원 재가입 및 탈퇴 회원 리뷰 처리 

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/member/domain/Member.java
+++ b/src/main/java/com/promesa/promesa/domain/member/domain/Member.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -32,6 +33,8 @@ public class Member extends BaseTimeEntity {
     private String providerId;
 
     private String phone;
+
+    @Builder.Default
     private Boolean smsAgree = true;
 
     @Enumerated(EnumType.STRING)
@@ -42,6 +45,7 @@ public class Member extends BaseTimeEntity {
     private Integer birthDay;
     private Boolean isSolar;
 
+    @Builder.Default
     private Boolean isDeleted = false;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
@@ -80,10 +84,6 @@ public class Member extends BaseTimeEntity {
 
     public void withdraw() {
         this.isDeleted = true;
+        this.providerId = this.providerId + "_withdrawn_" + UUID.randomUUID(); // providerId로 기존 회원을 찾을 수 없게 만들기
     }
-
-    public void restore() {
-        this.isDeleted = false;
-    }
-
 }

--- a/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/review/query/ReviewQueryRepository.java
@@ -53,7 +53,10 @@ public class ReviewQueryRepository {
         List<Long> reviewIds = queryFactory
                 .select(review.id)
                 .from(review)
-                .where(review.item.id.eq(itemId))
+                .where(
+                        review.item.id.eq(itemId),
+                        review.member.isDeleted.eq(false) // 탈퇴 회원 리뷰 제외
+                )
                 .orderBy(
                         review.rating.desc(),   // 리뷰 높은 순
                         Expressions.stringTemplate("char_length({0})", review.content).desc(),   // 글자 수 많은 순

--- a/src/main/java/com/promesa/promesa/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/promesa/promesa/security/oauth/CustomOAuth2UserService.java
@@ -31,17 +31,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String providerId = extractProviderId(provider, attributes);
         String name = extractName(provider, attributes);
 
-        // DB 기존 회원 조회 또는 신규 저장
+        //  1. 기존 회원 조회
         Member member = memberRepository
                 .findByProviderAndProviderId(provider, providerId)
-                .map(existing -> {
-                    if (Boolean.TRUE.equals(existing.getIsDeleted())) {
-                        // 탈퇴 회원 복구 처리
-                        existing.restore();
-                        return memberRepository.save(existing);
-                    }
-                    return existing;
-                })
                 .orElseGet(() -> memberRepository.save(Member.builder()
                         .name(name)
                         .provider(provider)

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -3,17 +3,18 @@ INSERT INTO member (
     member_id,
     name,
     provider,
-    provider_id
+    provider_id,
+    is_deleted
 ) VALUES
-      (1, '김회원',   'kakao', '1234'),
-      (2, '원회원',   'kakao', '5678'),
-      (3, '김작가',   'kakao', '1011'),
-      (4, '이작가',   'kakao', '1213'),
-      (5, '박작가',   'kakao', '1415'),
-      (6, '최작가',   'kakao', '1617'),
-      (7, '정작가',   'kakao', '1819'),
-      (8, '남궁회원', 'kakao', '2021'),
-      (9, '정회원',   'kakao', '2223');
+      (1, '김회원',   'kakao', '1234',false),
+      (2, '원회원',   'kakao', '5678',false),
+      (3, '김작가',   'kakao', '1011',false),
+      (4, '이작가',   'kakao', '1213',false),
+      (5, '박작가',   'kakao', '1415',false),
+      (6, '최작가',   'kakao', '1617',false),
+      (7, '정작가',   'kakao', '1819',false),
+      (8, '남궁회원', 'kakao', '2021',false),
+      (9, '정회원',   'kakao', '2223',false);
 
 -- 2. ARTIST
 INSERT INTO artist (


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #179 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 카카오 재로그인 시 새로운 회원으로 가입
  - 탈퇴 시에 providerId를 randomUUID로 바꿈
    -> 이후 기존 회원인지 확인할 때(findByProviderAndProviderId) 못 찾도록 만들기
- 탈퇴 회원의 리뷰 안 보이도록 처리
  - ReviewQueryRepository에서 isDeleted가 false인 회원의 리뷰만 보이도록 수정 
---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
