### PR TITLE
feat: 관리자 페이지 - 주문, 주문 아이템 조회 및 주문, 주문 아이템 상태 변경 

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/item/domain/Item.java
+++ b/src/main/java/com/promesa/promesa/domain/item/domain/Item.java
@@ -64,7 +64,7 @@ public class Item extends BaseTimeEntity {
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     private List<ExhibitionItem> exhibitionItems = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @OrderBy("sortOrder ASC")
     private List<ItemImage> itemImages = new ArrayList<>();
 

--- a/src/main/java/com/promesa/promesa/domain/order/api/AdminOrderController.java
+++ b/src/main/java/com/promesa/promesa/domain/order/api/AdminOrderController.java
@@ -1,0 +1,61 @@
+package com.promesa.promesa.domain.order.api;
+
+import com.promesa.promesa.domain.order.application.OrderService;
+import com.promesa.promesa.domain.order.domain.OrderItemStatus;
+import com.promesa.promesa.domain.order.domain.OrderStatus;
+import com.promesa.promesa.domain.order.dto.request.OrderItemStatusRequest;
+import com.promesa.promesa.domain.order.dto.request.OrderStatusRequest;
+import com.promesa.promesa.domain.order.dto.response.OrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminOrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "주문과 주문 아이템 목록 조회")
+    @GetMapping("/orders")
+    public ResponseEntity<List<OrderResponse>> getOrders(
+            @RequestParam(required = false) OrderStatus orderStatus,
+            @RequestParam(required = false) OrderItemStatus itemStatus
+    ) {
+        return ResponseEntity.ok(orderService.getOrders(orderStatus, itemStatus));
+    }
+
+    @Operation(summary = "주문 상태 변경")
+    @PatchMapping("/orders/{orderId}")
+    public ResponseEntity<String> updateOrderStatus(
+            @PathVariable Long orderId,
+            @RequestBody OrderStatusRequest request
+    ) {
+        orderService.updateOrderStatus(orderId, request.orderStatus());
+        String message = "주문 상태가 변경되었습니다.";
+        return ResponseEntity.ok(message);
+    }
+
+    @Operation(summary = "주문 아이템 상태 변경")
+    @PatchMapping("/order-items/{orderItemId}")
+    public ResponseEntity<String> updateOrderItemStatus(
+            @PathVariable Long orderItemId,
+            @RequestBody OrderItemStatusRequest request
+    ) {
+        orderService.updateOrderItemStatus(orderItemId, request.orderItemStatus());
+        String message = "주문 아이템 상태가 변경되었습니다.";
+        return ResponseEntity.ok(message);
+    }
+}

--- a/src/main/java/com/promesa/promesa/domain/order/api/OrderController.java
+++ b/src/main/java/com/promesa/promesa/domain/order/api/OrderController.java
@@ -4,7 +4,6 @@ import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.domain.order.application.OrderService;
 import com.promesa.promesa.domain.order.dto.response.OrderResponse;
 import com.promesa.promesa.domain.order.dto.request.OrderRequest;
-import com.promesa.promesa.domain.order.dto.response.OrderSummary;
 import com.promesa.promesa.domain.shippingAddress.application.ShippingAddressService;
 import com.promesa.promesa.domain.shippingAddress.dto.request.AddressRequest;
 import com.promesa.promesa.domain.shippingAddress.dto.response.AddressResponse;
@@ -56,15 +55,15 @@ public class OrderController {
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         Member member = user.getMember();
-        return ResponseEntity.ok(orderService.getOrderSummaries(member));
+        return ResponseEntity.ok(orderService.getOrders(member));
     }
 
     @GetMapping("/{orderId}")
     @Operation(summary = "주문 상세 내역 조회")
-    public ResponseEntity<OrderResponse> getOrderDetail(
+    public ResponseEntity<OrderResponse> getOrderDetails(
             @PathVariable Long orderId,
             @AuthenticationPrincipal CustomUserDetails user) {
         Member member = user.getMember();
-        return ResponseEntity.ok(orderService.getOrderDetail(member, orderId));
+        return ResponseEntity.ok(orderService.getOrderDetails(member, orderId));
     }
 }

--- a/src/main/java/com/promesa/promesa/domain/order/dao/OrderRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dao/OrderRepository.java
@@ -4,6 +4,8 @@ import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.domain.order.domain.Order;
 import com.promesa.promesa.domain.order.domain.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +14,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByMemberOrderByCreatedAtDesc(Member member);
     Optional<Order> findByIdAndMember(Long id, Member member);
 
-    List<Order> findByOrderStatus(OrderStatus orderStatus);
+    @Query("SELECT DISTINCT o FROM Order o JOIN FETCH o.orderItems i JOIN FETCH i.item it WHERE (:status IS NULL OR o.orderStatus = :status)")
+    List<Order> findWithItemsByStatus(@Param("status") OrderStatus orderStatus);
 }
 

--- a/src/main/java/com/promesa/promesa/domain/order/domain/Order.java
+++ b/src/main/java/com/promesa/promesa/domain/order/domain/Order.java
@@ -81,4 +81,8 @@ public class Order extends BaseTimeEntity {
     public void setTotalQuantity(int totalQuantity) {
         this.totalQuantity = totalQuantity;
     }
+
+    public void changeStatus(OrderStatus newStatus) {
+        this.orderStatus = newStatus;
+    }
 }

--- a/src/main/java/com/promesa/promesa/domain/order/domain/OrderItem.java
+++ b/src/main/java/com/promesa/promesa/domain/order/domain/OrderItem.java
@@ -58,5 +58,9 @@ public class OrderItem {
     public void setOrder(Order order) {
         this.order = order;
     }
+
+    public void changeStatus(OrderItemStatus newStatus) {
+        this.orderItemStatus = newStatus;
+    }
 }
 

--- a/src/main/java/com/promesa/promesa/domain/order/domain/OrderItemStatus.java
+++ b/src/main/java/com/promesa/promesa/domain/order/domain/OrderItemStatus.java
@@ -1,7 +1,6 @@
 package com.promesa.promesa.domain.order.domain;
 
 public enum OrderItemStatus {
-    ORDERED,               // 정상 주문
     CANCEL_REQUESTED,      // 취소 접수
     CANCELLED,             // 취소 완료
     RETURN_REQUESTED,      // 반품 접수

--- a/src/main/java/com/promesa/promesa/domain/order/dto/request/OrderItemStatusRequest.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dto/request/OrderItemStatusRequest.java
@@ -1,0 +1,6 @@
+package com.promesa.promesa.domain.order.dto.request;
+
+import com.promesa.promesa.domain.order.domain.OrderItemStatus;
+
+public record OrderItemStatusRequest(OrderItemStatus orderItemStatus) {}
+

--- a/src/main/java/com/promesa/promesa/domain/order/dto/request/OrderStatusRequest.java
+++ b/src/main/java/com/promesa/promesa/domain/order/dto/request/OrderStatusRequest.java
@@ -1,0 +1,5 @@
+package com.promesa.promesa.domain.order.dto.request;
+
+import com.promesa.promesa.domain.order.domain.OrderStatus;
+
+public record OrderStatusRequest(OrderStatus orderStatus) {}


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #196 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
### 주문, 주문 아이템 목록 조회
GET /admin/orders
- **필터: OrderStatus, OrderItemStatus (쿼리 파라미터)**
- 용도:
  - 특정 주문 상태 조회 (예: WAITING_FOR_PAYMENT)
  - 주문 아이템의 요청 상태 조회 (예: CANCEL_REQUESTED, RETURN_REQUESTED 등)

### 주문 상태 변경
PATCH /admin/orders/{orderId}
- 변경 예시:
  - WAITING_FOR_PAYMENT → PAID
  - WAITING_FOR_PAYMENT → NO_PAYMENT
- 성공 시 메시지만 반환

### 주문 아이템 상태 변경
PATCH /admin/order-items/{orderItemId}
- 변경 예시:
  - CANCEL_REQUESTED → CANCELLED
  - RETURN_REQUESTED → RETURNED
  - EXCHANGE_REQUESTED → EXCHANGED
- 성공 시 메시지만 반환

---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->

- 지금은 상태 변경 예외처리 걸어놓지 않아서 **이전에 어떤 상태였는지 검증하지 않음.**
  - 이후 필요하다면 추가예정!!

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
