### PR TITLE
feat: 동시성 이슈 해결 

### DIFF
--- a/src/main/java/com/promesa/promesa/domain/category/api/CategoryController.java
+++ b/src/main/java/com/promesa/promesa/domain/category/api/CategoryController.java
@@ -3,6 +3,7 @@ package com.promesa.promesa.domain.category.api;
 import com.promesa.promesa.domain.category.application.CategoryService;
 import com.promesa.promesa.domain.category.domain.Category;
 import com.promesa.promesa.domain.category.dto.CategoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,12 +20,15 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping("/parent")
+    @Operation(summary = "작품 카테고리 조회")
     public ResponseEntity<List<CategoryResponse>> getParentCategories() {
         return ResponseEntity.ok(categoryService.getParentCategories());
     }
-
+/*
     @GetMapping("/child")
+    @Operation(summary = "작품 하위 카테고리 조회")
     public ResponseEntity<List<CategoryResponse>> getChildCategories(@RequestParam Long parentId) {
         return ResponseEntity.ok(categoryService.getChildCategories(parentId));
     }
+ */
 }

--- a/src/main/java/com/promesa/promesa/domain/home/api/HomeController.java
+++ b/src/main/java/com/promesa/promesa/domain/home/api/HomeController.java
@@ -5,6 +5,7 @@ import com.promesa.promesa.domain.home.dto.response.BrandInfoResponse;
 import com.promesa.promesa.domain.home.dto.response.SearchResponse;
 import com.promesa.promesa.domain.member.domain.Member;
 import com.promesa.promesa.security.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,11 +19,13 @@ public class HomeController {
     private final HomeService homeService;
 
     @GetMapping("/brand-info")
+    @Operation(summary = "브랜드 정보")
     public ResponseEntity<BrandInfoResponse> getBrandInfo() {
         return ResponseEntity.ok(homeService.getBrandInfo());
     }
 
     @GetMapping("/search")
+    @Operation(summary = "검색")
     public ResponseEntity<SearchResponse> getBrandInfo(
             @RequestParam String keyword,
             @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/com/promesa/promesa/domain/inquiry/api/InquiryController.java
+++ b/src/main/java/com/promesa/promesa/domain/inquiry/api/InquiryController.java
@@ -21,6 +21,7 @@ public class InquiryController {
     private final InquiryService inquiryService;
 
     @GetMapping
+    @Operation(summary = "문의 목록 조회")
     public ResponseEntity<List<InquiryResponse>> getInquiriesByArtist(@RequestParam Long artistId) {
         return ResponseEntity.ok(inquiryService.getInquiriesByArtist(artistId));
     }

--- a/src/main/java/com/promesa/promesa/domain/item/api/ItemController.java
+++ b/src/main/java/com/promesa/promesa/domain/item/api/ItemController.java
@@ -26,6 +26,7 @@ public class ItemController {
     private final ItemInfoService itemInfoService;
 
     @GetMapping("/categories/{categoryId}/items")
+    @Operation(summary = "카테고리별 작품 목록")
     public ResponseEntity<Page<ItemPreviewResponse>> findCategoryItem(
             @PathVariable Long categoryId,
             @AuthenticationPrincipal CustomUserDetails user,
@@ -37,6 +38,7 @@ public class ItemController {
     }
 
     @GetMapping("/items/{itemId}")
+    @Operation(summary = "작품 상세 조회")
     public ItemResponse getItem(
             @PathVariable Long itemId,
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/promesa/promesa/domain/item/dao/ItemRepository.java
+++ b/src/main/java/com/promesa/promesa/domain/item/dao/ItemRepository.java
@@ -1,12 +1,22 @@
 package com.promesa.promesa.domain.item.dao;
 
 import com.promesa.promesa.domain.item.domain.Item;
+import jakarta.persistence.LockModeType;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
     boolean existsByProductCode(String productCode);
 
     boolean existsByProductCodeAndIdNot(String code, Long existingItemId);
-    // 기본 findById 사용
+
+    // 비관적 락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM Item i WHERE i.id = :id")
+    Optional<Item> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/promesa/promesa/domain/order/application/OrderService.java
+++ b/src/main/java/com/promesa/promesa/domain/order/application/OrderService.java
@@ -78,7 +78,7 @@ public class OrderService {
 
             orderItems = request.items().stream()
                     .map(req -> {
-                        Item item = itemRepository.findById(req.itemId())
+                        Item item = itemRepository.findByIdForUpdate(req.itemId())
                                 .orElseThrow(() -> ItemNotFoundException.EXCEPTION);
                         item.decreaseStock(req.quantity()); // 재고 감소
                         return OrderItem.of(order, item, req.quantity(), item.getPrice());
@@ -106,7 +106,8 @@ public class OrderService {
 
             orderItems = cartItems.stream()
                     .map(cartItem -> {
-                        Item item = cartItem.getItem();
+                        Item item = itemRepository.findByIdForUpdate(cartItem.getItem().getId())
+                                .orElseThrow(() -> ItemNotFoundException.EXCEPTION);
                         item.decreaseStock(cartItem.getQuantity()); // 재고 감소
                         return OrderItem.of(order, item, cartItem.getQuantity(), item.getPrice());
                     }).toList();

--- a/src/main/java/com/promesa/promesa/domain/wish/api/WishController.java
+++ b/src/main/java/com/promesa/promesa/domain/wish/api/WishController.java
@@ -8,6 +8,7 @@ import com.promesa.promesa.domain.wish.domain.TargetType;
 import com.promesa.promesa.domain.wish.dto.WishResponse;
 import com.promesa.promesa.domain.wish.dto.WishToggleResponse;
 import com.promesa.promesa.security.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,6 +30,7 @@ public class WishController {
     private final WishService wishService;
 
     @PostMapping
+    @Operation(summary = "위시리스트/북마크 추가")
     public ResponseEntity<WishToggleResponse> addWish(
             @RequestParam TargetType targetType,
             @RequestParam Long targetId,
@@ -40,6 +42,7 @@ public class WishController {
     }
 
     @DeleteMapping
+    @Operation(summary = "위시리스트/북마크 삭제")
     public ResponseEntity<WishToggleResponse> deleteWish(
             @RequestParam TargetType targetType,
             @RequestParam Long targetId,
@@ -51,6 +54,7 @@ public class WishController {
     }
 
     @GetMapping("/list")
+    @Operation(summary = "내 위시리스트/북마크 목록 조회")
     public ResponseEntity<List<WishResponse>> getWishList(
             @RequestParam TargetType targetType,
             @AuthenticationPrincipal CustomUserDetails user
@@ -60,7 +64,9 @@ public class WishController {
         return ResponseEntity.ok(wishes);
     }
 
+/*
     @GetMapping("/item/{itemId}")
+    @Operation(summary = "작품 위시리스트 여부 조회")
     public ResponseEntity<ItemWish> getItemWish(
             @PathVariable Long itemId,
             @AuthenticationPrincipal CustomUserDetails user) {
@@ -69,11 +75,14 @@ public class WishController {
     }
 
     @GetMapping("/artist/{artistId}")
+    @Operation(summary = "작가 북마크 여부 조회")
     public ResponseEntity<ArtistWish> getArtistWish(
             @PathVariable Long artistId,
             @AuthenticationPrincipal CustomUserDetails user) {
         Member member = (user != null) ? user.getMember() : null;
         return ResponseEntity.ok(wishService.getArtistWish(artistId, member));
+
     }
+ */
 }
 

--- a/src/main/java/com/promesa/promesa/security/dev/DevTokenController.java
+++ b/src/main/java/com/promesa/promesa/security/dev/DevTokenController.java
@@ -2,6 +2,7 @@ package com.promesa.promesa.security.dev;
 
 import com.promesa.promesa.security.jwt.JwtTokenProvider;
 import com.promesa.promesa.security.jwt.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,10 +13,10 @@ import java.util.List;
 @RequestMapping("/dev")
 public class DevTokenController {
 
-    private final JwtTokenProvider jwtTokenProvider;
     private final JwtUtil jwtUtil;
 
     @PostMapping("/test-token")
+    @Operation(summary = "테스트용 액세스 토큰 발급 (개발 전용)")
     public String generateTestToken(@RequestParam(defaultValue = "kakao:1234") String nickname) {
         List<String> roles = List.of("ROLE_USER", "ROLE_ADMIN");
         return jwtUtil.createAccessToken(nickname, roles); // 운영 토큰처럼 claim 다 넣기

--- a/src/main/java/com/promesa/promesa/security/jwt/refresh/RefreshController.java
+++ b/src/main/java/com/promesa/promesa/security/jwt/refresh/RefreshController.java
@@ -1,6 +1,7 @@
 package com.promesa.promesa.security.jwt.refresh;
 
 import com.promesa.promesa.common.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class RefreshController {
     private final RefreshService refreshService;
 
     @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급")
     public ResponseEntity<SuccessResponse<?>> reissue(HttpServletRequest request, HttpServletResponse response) {
         return ResponseEntity.ok(refreshService.reissue(request, response));
     }

--- a/src/main/java/com/promesa/promesa/security/logout/LogoutController.java
+++ b/src/main/java/com/promesa/promesa/security/logout/LogoutController.java
@@ -1,6 +1,7 @@
 package com.promesa.promesa.security.logout;
 
 import com.promesa.promesa.common.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class LogoutController {
     private final LogoutService logoutService;
 
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃")
     public ResponseEntity<SuccessResponse<String>> logout(HttpServletRequest request, HttpServletResponse response) {
         return ResponseEntity.ok(logoutService.logout(request, response));
     }

--- a/src/test/java/com/promesa/promesa/domain/order/OrderServiceConcurrencyTest.java
+++ b/src/test/java/com/promesa/promesa/domain/order/OrderServiceConcurrencyTest.java
@@ -1,0 +1,105 @@
+package com.promesa.promesa.domain.order;
+
+import com.promesa.promesa.domain.item.dao.ItemRepository;
+import com.promesa.promesa.domain.item.domain.Item;
+import com.promesa.promesa.domain.member.dao.MemberRepository;
+import com.promesa.promesa.domain.member.domain.Member;
+import com.promesa.promesa.domain.order.application.OrderService;
+import com.promesa.promesa.domain.order.dto.request.OrderItemRequest;
+import com.promesa.promesa.domain.order.dto.request.OrderRequest;
+import com.promesa.promesa.domain.order.dto.request.PaymentRequest;
+import com.promesa.promesa.domain.shippingAddress.dto.request.AddressRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+@SpringBootTest(properties = {
+        "spring.security.oauth2.client.registration.kakao.client-id=dummy",
+        "spring.security.oauth2.client.registration.kakao.client-secret=dummy",
+        "spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost"
+})
+class OrderServiceConcurrencyTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 동시에_주문하면_재고가_음수가_되지_않는다() throws InterruptedException {
+        // given
+        Member member1 = memberRepository.save(Member.builder()
+                .name("김회원")
+                .provider("kakao")
+                .providerId("test1234")
+                .build());
+
+        Member member2 = memberRepository.save(Member.builder()
+                .name("정회원")
+                .provider("kakao")
+                .providerId("test5678")
+                .build());
+
+        Item item = itemRepository.save(Item.builder()
+                .name("동시성 테스트 작품")
+                .stock(1)          // 재고 1
+                .price(10000)
+                .productCode("TEST-CODE-001")
+                .build());
+
+        OrderRequest orderRequest = new OrderRequest(
+                "SINGLE",
+                List.of(new OrderItemRequest(item.getId(), 1)),
+                new AddressRequest(
+                        "홍길동",
+                        "12345",
+                        "서울시 강남구",
+                        "역삼동 101호",
+                        "010-1234-5678"
+                ),
+                new PaymentRequest(
+                        "무통장입금",
+                        "신한은행 123-456-789098",
+                        "홍길동"
+                )
+        );
+
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            Member member = (i == 0) ? member1 : member2;
+            executor.submit(() -> {
+                try {
+                    orderService.createOrder(orderRequest, member);
+                } catch (Exception e) {
+                    System.out.println("❌ 실패한 주문: " + e.getClass().getSimpleName());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        Item updated = itemRepository.findById(item.getId()).get();
+        System.out.println("✅ 남은 재고: " + updated.getStock());
+        assertThat(updated.getStock()).isGreaterThanOrEqualTo(0);
+    }
+
+}
+


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 적고 이슈를 close 해주세요-->
<!--- ex) #이슈번호, #이슈번호 -->

- close #198 

## 🛠️ 작업 내용

<!-- 작업한 내용을 적어주세요-->
- 주문 생성 시 재고 동시성 문제 해결
  - ItemRepository.findByIdForUpdate()로 **비관적 락(Pessimistic Lock)** 적용
  - 하나의 작품에 대해 동시에 주문 요청이 들어올 경우, 재고가 음수가 되지 않도록 동시성 제어
- 관련 동시성 테스트 OrderServiceConcurrencyTest 작성 및 성공 확인
<img width="2656" height="1134" alt="image" src="https://github.com/user-attachments/assets/ff9d3d14-9f18-41bc-bfd4-f1b7ad2f2e81" />


---
### 📌 특이 사항

<!-- 팀원이 알아야 할 사항을 적어주세요 -->
<!-- 논의해야할 부분이 있다면 적어주세요 -->
테스트 환경에서는 @Transactional을 제거하고, 실제 DB 반영 타이밍에 맞춰 동작 확인

### 📚 참고 자료

<!--- 작업 시 참고한 자료를 공유해주세요 -->
